### PR TITLE
feat: add layered chat tool dispatcher

### DIFF
--- a/app/api/chat/tools.ts
+++ b/app/api/chat/tools.ts
@@ -12,7 +12,8 @@ export const toolSchemas: ToolSchema[] = [
     schema: {
       type: "object",
       properties: {
-        query: { type: "string", description: "e.g., 'black leather chelsea boots women'" },
+        query: { type: "string", description: "Keywords or URL for the desired product" },
+        url: { type: "string", description: "Direct product URL to inspect" },
         country: { type: "string" },
         currency: { type: "string" },
         budgetMax: { type: "number" },
@@ -32,6 +33,7 @@ export const toolSchemas: ToolSchema[] = [
       properties: {
         productId: { type: "string" },
         country: { type: "string" },
+        currency: { type: "string" },
       },
       required: ["productId", "country"],
     },
@@ -41,7 +43,10 @@ export const toolSchemas: ToolSchema[] = [
     description: "Convert a product URL to an affiliate-safe link",
     schema: {
       type: "object",
-      properties: { url: { type: "string" }, retailer: { type: "string" } },
+      properties: {
+        url: { type: "string" },
+        retailer: { type: "string" },
+      },
       required: ["url"],
     },
   },
@@ -54,102 +59,41 @@ export const toolSchemas: ToolSchema[] = [
       required: ["imageUrl"],
     },
   },
+  {
+    name: "fx_convert",
+    description: "Convert an amount between currencies",
+    schema: {
+      type: "object",
+      properties: {
+        amount: { type: "number" },
+        from: { type: "string", description: "Source currency (e.g. EUR)" },
+        to: { type: "string", description: "Target currency (e.g. USD)" },
+        precision: { type: "number", description: "Decimal places for rounding" },
+      },
+      required: ["amount", "from", "to"],
+    },
+  },
 ];
 
-// ===== Demo internals (replace with real retailer APIs when ready) =====
-function euro(n: number) { return { price: n, currency: "EUR" as const }; }
+export { createToolDispatcher } from "./tools/index";
+export type {
+  ToolDispatcher,
+  ToolAdapter,
+  ToolContext,
+  ToolName,
+  SearchProductsArgs,
+  SearchProductsResponse,
+  CheckStockArgs,
+  CheckStockResponse,
+  AffiliateLinkArgs,
+  AffiliateLinkResponse,
+  PaletteFromImageArgs,
+  PaletteFromImageResponse,
+  FxConvertArgs,
+  FxConvertResponse,
+  NormalizedProduct,
+} from "./tools/index";
 
-async function demoSearch(args: any) {
-  const q = (args?.query || "").toLowerCase();
-  // Return a tiny believable catalog (with imageUrl).
-  const db = [
-    {
-      id: "tw-top-003",
-      brand: "Toteme",
-      title: "Contour Rib Long-Sleeve",
-      ...euro(160),
-      retailer: "SSENSE",
-      url: "https://www.ssense.example/toteme-contour-rib",
-      color: "ivory",
-      sizes: ["XS", "S", "M", "L"],
-      imageUrl: "https://images.example.com/toteme_rib_ivory.jpg",
-    },
-    {
-      id: "tw-trouser-002",
-      brand: "COS",
-      title: "Tailored Tapered Wool Trousers",
-      ...euro(120),
-      retailer: "COS",
-      url: "https://www.cos.example/tapered-wool-trouser",
-      color: "charcoal",
-      sizes: ["34", "36", "38", "40", "42"],
-      imageUrl: "https://images.example.com/cos_tapered_charcoal.jpg",
-    },
-    {
-      id: "tw-outer-010",
-      brand: "Arket",
-      title: "Double-Faced Wool Coat",
-      ...euro(260),
-      retailer: "Arket",
-      url: "https://www.arket.example/dbl-coat",
-      color: "black",
-      sizes: ["XS", "S", "M", "L"],
-      imageUrl: "https://images.example.com/arket_coat_black.jpg",
-    },
-    {
-      id: "tw-boot-001",
-      brand: "Aeyde",
-      title: "Elongated Leather Ankle Boots",
-      ...euro(295),
-      retailer: "Zalando",
-      url: "https://www.zalando.example/aeyde-elong-boot",
-      color: "black",
-      sizes: ["36", "37", "38", "39", "40", "41"],
-      imageUrl: "https://images.example.com/aeyde_ankle_boot.jpg",
-    },
-    {
-      id: "tw-bag-020",
-      brand: "Staud",
-      title: "Leather Shoulder Bag",
-      ...euro(225),
-      retailer: "SSENSE",
-      url: "https://www.ssense.example/staud-shoulder",
-      color: "black",
-      sizes: [],
-      imageUrl: "https://images.example.com/staud_shoulder_black.jpg",
-    },
-    {
-      id: "tw-acc-030",
-      brand: "Mejuri",
-      title: "Bold Gold Hoop Earrings",
-      ...euro(95),
-      retailer: "Mejuri",
-      url: "https://www.mejuri.example/gold-hoop",
-      color: "gold",
-      sizes: [],
-      imageUrl: "https://images.example.com/mejuri_hoop_gold.jpg",
-    },
-  ];
-
-  const items = db.filter((it) =>
-    q.split(/\s+/).every((w: string) => it.title.toLowerCase().includes(w) || it.brand.toLowerCase().includes(w) || it.color.toLowerCase().includes(w))
-  );
-
-  return { items: items.length ? items : db.slice(0, 3), query: args?.query };
-}
-
-export async function runTool(name: string, args: any, _ctx?: any) {
-  switch (name) {
-    case "retailer_search":
-      return demoSearch(args);
-    case "stock_check":
-      return { productId: args.productId, country: args.country, inStock: true, price: 149, currency: "EUR" };
-    case "affiliate_link":
-      return { url: args.url + "?affid=runwaytwin", retailer: args.retailer || null };
-    case "palette_from_image":
-      return { colors: ["#2E2E2E", "#8B8B8B", "#EAEAEA", "#3A5F5F", "#C7A27A"] };
-    default:
-      throw new Error(`Unknown tool: ${name}`);
-  }
-}
-
+export { demoAdapter } from "./tools/adapters/demoAdapter";
+export { webAdapter } from "./tools/adapters/webAdapter";
+export { awinAdapter } from "./tools/adapters/awinAdapter";

--- a/app/api/chat/tools/adapters/awinAdapter.ts
+++ b/app/api/chat/tools/adapters/awinAdapter.ts
@@ -1,0 +1,48 @@
+// app/api/chat/tools/adapters/awinAdapter.ts
+import type {
+  AffiliateLinkArgs,
+  AffiliateLinkResponse,
+  SearchProductsArgs,
+  ToolAdapter,
+  ToolContext,
+} from "../index";
+
+const AWIN_SOURCE = "awin";
+
+function hasToken() {
+  return Boolean(process.env.AWIN_API_TOKEN);
+}
+
+export const awinAdapter: ToolAdapter = {
+  id: AWIN_SOURCE,
+  async searchProducts(_args: SearchProductsArgs, _ctx: ToolContext) {
+    if (!hasToken()) return null;
+    const started = Date.now();
+    return {
+      items: [],
+      source: AWIN_SOURCE,
+      latency: Date.now() - started,
+      meta: { status: "pending-integration" },
+    };
+  },
+  async affiliateLink(args: AffiliateLinkArgs) {
+    if (!hasToken()) return null;
+    const started = Date.now();
+    return {
+      url: args.url,
+      retailer: args.retailer || retailerFromUrl(args.url) || null,
+      source: AWIN_SOURCE,
+      latency: Date.now() - started,
+      meta: { passthrough: true },
+    } satisfies AffiliateLinkResponse;
+  },
+};
+
+function retailerFromUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.replace(/^www\./i, "");
+  } catch {
+    return null;
+  }
+}

--- a/app/api/chat/tools/adapters/demoAdapter.ts
+++ b/app/api/chat/tools/adapters/demoAdapter.ts
@@ -1,0 +1,244 @@
+// app/api/chat/tools/adapters/demoAdapter.ts
+import type {
+  AffiliateLinkArgs,
+  AffiliateLinkResponse,
+  FxConvertArgs,
+  FxConvertResponse,
+  PaletteFromImageArgs,
+  PaletteFromImageResponse,
+  SearchProductsArgs,
+  ToolAdapter,
+  ToolContext,
+  CheckStockArgs,
+  CheckStockResponse,
+  AdapterProduct,
+} from "../index";
+
+const DEMO_SOURCE = "demo";
+
+const demoCatalog: AdapterProduct[] = [
+  {
+    id: "tw-top-003",
+    brand: "Toteme",
+    title: "Contour Rib Long-Sleeve",
+    price: 160,
+    currency: "EUR",
+    retailer: "SSENSE",
+    url: "https://www.ssense.example/toteme-contour-rib",
+    color: "ivory",
+    sizes: ["XS", "S", "M", "L"],
+    image: "https://images.example.com/toteme_rib_ivory.jpg",
+    stock: true,
+  },
+  {
+    id: "tw-trouser-002",
+    brand: "COS",
+    title: "Tailored Tapered Wool Trousers",
+    price: 120,
+    currency: "EUR",
+    retailer: "COS",
+    url: "https://www.cos.example/tapered-wool-trouser",
+    color: "charcoal",
+    sizes: ["34", "36", "38", "40", "42"],
+    image: "https://images.example.com/cos_tapered_charcoal.jpg",
+    stock: true,
+  },
+  {
+    id: "tw-outer-010",
+    brand: "Arket",
+    title: "Double-Faced Wool Coat",
+    price: 260,
+    currency: "EUR",
+    retailer: "Arket",
+    url: "https://www.arket.example/dbl-coat",
+    color: "black",
+    sizes: ["XS", "S", "M", "L"],
+    image: "https://images.example.com/arket_coat_black.jpg",
+    stock: true,
+  },
+  {
+    id: "tw-boot-001",
+    brand: "Aeyde",
+    title: "Elongated Leather Ankle Boots",
+    price: 295,
+    currency: "EUR",
+    retailer: "Zalando",
+    url: "https://www.zalando.example/aeyde-elong-boot",
+    color: "black",
+    sizes: ["36", "37", "38", "39", "40", "41"],
+    image: "https://images.example.com/aeyde_ankle_boot.jpg",
+    stock: true,
+  },
+  {
+    id: "tw-bag-020",
+    brand: "Staud",
+    title: "Leather Shoulder Bag",
+    price: 225,
+    currency: "EUR",
+    retailer: "SSENSE",
+    url: "https://www.ssense.example/staud-shoulder",
+    color: "black",
+    sizes: [],
+    image: "https://images.example.com/staud_shoulder_black.jpg",
+    stock: true,
+  },
+  {
+    id: "tw-acc-030",
+    brand: "Mejuri",
+    title: "Bold Gold Hoop Earrings",
+    price: 95,
+    currency: "EUR",
+    retailer: "Mejuri",
+    url: "https://www.mejuri.example/gold-hoop",
+    color: "gold",
+    sizes: [],
+    image: "https://images.example.com/mejuri_hoop_gold.jpg",
+    stock: true,
+  },
+];
+
+function tokens(text: string) {
+  return text
+    .toLowerCase()
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+function itemMatches(item: AdapterProduct, terms: string[]) {
+  if (!terms.length) return true;
+  const haystack = [item.title, item.brand, item.color]
+    .map((s) => (typeof s === "string" ? s.toLowerCase() : ""))
+    .join(" ");
+  return terms.every((t) => haystack.includes(t));
+}
+
+function clampLimit(limit?: number) {
+  if (!Number.isFinite(limit || NaN)) return 6;
+  return Math.max(1, Math.min(20, Math.floor(Number(limit))));
+}
+
+function makePalette(imageUrl: string, swatches = 5) {
+  const base = ["#2E2E2E", "#7F7F7F", "#EDE9E3", "#C7A27A", "#4A646C", "#B59DA4", "#22303C"];
+  const count = Math.max(1, Math.min(swatches, base.length));
+  if (!imageUrl) return base.slice(0, count);
+  let hash = 0;
+  for (let i = 0; i < imageUrl.length; i += 1) {
+    hash = (hash * 33 + imageUrl.charCodeAt(i)) % base.length;
+  }
+  const rotated = [...base.slice(hash), ...base.slice(0, hash)];
+  return rotated.slice(0, count);
+}
+
+function convertFx(args: FxConvertArgs): FxConvertResponse {
+  const start = Date.now();
+  const from = (args.from || "EUR").toUpperCase();
+  const to = (args.to || "EUR").toUpperCase();
+  const amount = Number(args.amount || 0);
+  const precision = Number.isFinite(args.precision || NaN)
+    ? Math.max(0, Math.min(4, Math.floor(Number(args.precision))))
+    : 2;
+  const matrix: Record<string, Record<string, number>> = {
+    EUR: { USD: 1.08, GBP: 0.86, EUR: 1 },
+    USD: { EUR: 0.93, GBP: 0.80, USD: 1 },
+    GBP: { EUR: 1.16, USD: 1.24, GBP: 1 },
+  };
+  const rate = matrix[from]?.[to] ?? 1;
+  const converted = Number((amount * rate).toFixed(precision));
+  return {
+    amount: converted,
+    currency: to,
+    rate,
+    source: DEMO_SOURCE,
+    latency: Date.now() - start,
+  };
+}
+
+function makeAffiliateLink(args: AffiliateLinkArgs): AffiliateLinkResponse {
+  const started = Date.now();
+  try {
+    const url = new URL(args.url);
+    url.searchParams.set("affid", "runwaytwin-demo");
+    return {
+      url: url.toString(),
+      retailer: args.retailer || url.hostname.replace(/^www\./i, ""),
+      source: DEMO_SOURCE,
+      latency: Date.now() - started,
+    };
+  } catch {
+    return {
+      url: args.url,
+      retailer: args.retailer || null,
+      source: DEMO_SOURCE,
+      latency: Date.now() - started,
+    };
+  }
+}
+
+function checkDemoStock(args: CheckStockArgs): CheckStockResponse {
+  const started = Date.now();
+  const match = demoCatalog.find((item) => item.id === args.productId || item.url === args.productId);
+  if (!match) {
+    return {
+      productId: args.productId,
+      inStock: false,
+      source: DEMO_SOURCE,
+      latency: Date.now() - started,
+    };
+  }
+  return {
+    productId: match.id || args.productId,
+    inStock: match.stock !== false,
+    price: typeof match.price === "number" ? match.price : undefined,
+    currency: typeof match.currency === "string" ? match.currency : undefined,
+    retailer: typeof match.retailer === "string" ? match.retailer : undefined,
+    url: typeof match.url === "string" ? match.url : undefined,
+    image: typeof match.image === "string" ? match.image : undefined,
+    sizes: Array.isArray(match.sizes) ? match.sizes.map(String) : undefined,
+    source: DEMO_SOURCE,
+    latency: Date.now() - started,
+  };
+}
+
+function demoPalette(args: PaletteFromImageArgs): PaletteFromImageResponse {
+  const started = Date.now();
+  return {
+    colors: makePalette(args.imageUrl, args.swatches),
+    source: DEMO_SOURCE,
+    latency: Date.now() - started,
+  };
+}
+
+function searchDemoCatalog(args: SearchProductsArgs, _ctx: ToolContext) {
+  const started = Date.now();
+  const terms = tokens(args.query || "");
+  const limit = clampLimit(args.limit);
+  let items = demoCatalog.filter((item) => itemMatches(item, terms));
+  if (!items.length) items = demoCatalog.slice(0, limit);
+  const sliced = items.slice(0, limit).map((item) => ({ ...item }));
+  return {
+    items: sliced,
+    source: DEMO_SOURCE,
+    latency: Date.now() - started,
+    meta: { total: items.length },
+  };
+}
+
+export const demoAdapter: ToolAdapter = {
+  id: DEMO_SOURCE,
+  async searchProducts(args: SearchProductsArgs, ctx: ToolContext) {
+    return searchDemoCatalog(args, ctx);
+  },
+  async checkStock(args: CheckStockArgs) {
+    return checkDemoStock(args);
+  },
+  async affiliateLink(args: AffiliateLinkArgs) {
+    return makeAffiliateLink(args);
+  },
+  async paletteFromImage(args: PaletteFromImageArgs) {
+    return demoPalette(args);
+  },
+  async fxConvert(args: FxConvertArgs) {
+    return convertFx(args);
+  },
+};

--- a/app/api/chat/tools/adapters/webAdapter.ts
+++ b/app/api/chat/tools/adapters/webAdapter.ts
@@ -1,0 +1,286 @@
+// app/api/chat/tools/adapters/webAdapter.ts
+import type {
+  AdapterProduct,
+  SearchProductsArgs,
+  ToolAdapter,
+  ToolContext,
+} from "../index";
+
+const WEB_SOURCE = "web";
+const USER_AGENT =
+  "RunwayTwinBot/1.0 (+https://runwaytwin.app/tools; contact@runwaytwin.app)";
+
+export const webAdapter: ToolAdapter = {
+  id: WEB_SOURCE,
+  async searchProducts(args: SearchProductsArgs, ctx: ToolContext) {
+    const started = Date.now();
+    const candidateUrl = pickUrlCandidate(args);
+    if (!candidateUrl) return null;
+
+    try {
+      const fetcher = ctx.fetch || fetch;
+      const res = await fetcher(candidateUrl, {
+        method: "GET",
+        headers: {
+          "User-Agent": USER_AGENT,
+          Accept: "text/html,application/xhtml+xml",
+          ...(ctx.headers || {}),
+        },
+        signal: ctx.signal,
+      });
+
+      if (!res.ok) {
+        return {
+          items: [],
+          source: WEB_SOURCE,
+          latency: Date.now() - started,
+          meta: { status: res.status, url: candidateUrl },
+        };
+      }
+
+      const html = await res.text();
+      const doc = parseHtml(html);
+      const jsonLdNodes = extractJsonLd(doc, html);
+      let product = extractProduct(jsonLdNodes, candidateUrl);
+      if (!product) {
+        product = extractFromHtml(doc, candidateUrl);
+      }
+      if (product) {
+        if (!product.url) product.url = candidateUrl;
+        if (!product.retailer) product.retailer = retailerFromUrl(candidateUrl) || undefined;
+      }
+
+      return {
+        items: product ? [product] : [],
+        source: WEB_SOURCE,
+        latency: Date.now() - started,
+        meta: { url: candidateUrl, jsonLd: jsonLdNodes.length },
+      };
+    } catch (err: any) {
+      return {
+        items: [],
+        source: WEB_SOURCE,
+        latency: Date.now() - started,
+        meta: { url: candidateUrl, error: err?.message || "fetch failed" },
+      };
+    }
+  },
+};
+
+function pickUrlCandidate(args: SearchProductsArgs): string | null {
+  const direct = typeof args.url === "string" && args.url.trim();
+  if (direct && isLikelyUrl(direct)) return direct;
+  const q = typeof args.query === "string" ? args.query.trim() : "";
+  if (q && isLikelyUrl(q)) return q;
+  return null;
+}
+
+function isLikelyUrl(candidate: string) {
+  try {
+    const parsed = new URL(candidate);
+    return Boolean(parsed.protocol && parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function parseHtml(html: string): Document | null {
+  if (typeof DOMParser === "undefined") return null;
+  try {
+    const parser = new DOMParser();
+    return parser.parseFromString(html, "text/html");
+  } catch {
+    return null;
+  }
+}
+
+function extractJsonLd(doc: Document | null, html: string): any[] {
+  const scripts: string[] = [];
+  if (doc) {
+    const nodes = Array.from(
+      doc.querySelectorAll('script[type="application/ld+json"]')
+    );
+    for (const node of nodes) {
+      const text = node.textContent || node.innerHTML || "";
+      if (text.trim()) scripts.push(text.trim());
+    }
+  } else {
+    const regex = /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(html))) {
+      if (match[1] && match[1].trim()) scripts.push(match[1].trim());
+    }
+  }
+
+  const parsed: any[] = [];
+  for (const script of scripts) {
+    const node = safeJsonParse(script);
+    if (node != null) parsed.push(node);
+  }
+  return parsed;
+}
+
+function extractProduct(nodes: any[], fallbackUrl: string): AdapterProduct | null {
+  const queue = [...nodes];
+  while (queue.length) {
+    const current = queue.shift();
+    if (!current) continue;
+
+    if (Array.isArray(current)) {
+      queue.push(...current);
+      continue;
+    }
+
+    if (typeof current !== "object") continue;
+
+    const type = (current as any)["@type"];
+    const types = Array.isArray(type) ? type : type ? [type] : [];
+    if (types.some((t) => typeof t === "string" && /product/i.test(t))) {
+      return mapProductNode(current, fallbackUrl);
+    }
+
+    if (current["@graph"]) queue.push(current["@graph"]);
+    if (current.itemListElement) queue.push(current.itemListElement);
+    if (current.mainEntity) queue.push(current.mainEntity);
+  }
+  return null;
+}
+
+function mapProductNode(node: any, fallbackUrl: string): AdapterProduct {
+  const offers = Array.isArray(node.offers) ? node.offers[0] : node.offers;
+  const offerSpec = offers?.priceSpecification || offers?.priceSpecifications;
+  const seller = offers?.seller || node.seller;
+  const image = Array.isArray(node.image) ? node.image[0] : node.image;
+  const price =
+    offers?.price ??
+    offerSpec?.price ??
+    node.price ??
+    node.priceAmount ??
+    node.priceValue;
+  const priceCurrency =
+    offers?.priceCurrency ??
+    offerSpec?.priceCurrency ??
+    node.priceCurrency;
+  const availability = offers?.availability || node.availability;
+
+  return {
+    id: node.sku || node.productID || node["@id"],
+    sku: node.sku,
+    brand: node.brand,
+    title: node.name || node.title,
+    description: node.description,
+    price,
+    priceCurrency,
+    currency: priceCurrency,
+    seller,
+    retailer: seller?.name || seller,
+    image,
+    url: node.url || fallbackUrl,
+    availability,
+    inStock: typeof availability === "string" ? /instock|in stock/i.test(availability) : undefined,
+    colors: node.color,
+    sizes: node.size || node.sizes,
+  } as AdapterProduct;
+}
+
+function extractFromHtml(doc: Document | null, url: string): AdapterProduct | null {
+  if (!doc) return null;
+
+  const title = getText(doc, [
+    'meta[property="og:title"]',
+    'meta[name="twitter:title"]',
+    "title",
+    "h1",
+  ]);
+  if (!title) return null;
+
+  const image = getAttr(doc, [
+    'meta[property="og:image"]',
+    'meta[name="twitter:image"]',
+    'link[rel="image_src"]',
+  ]);
+
+  const price = getAttr(doc, [
+    'meta[property="product:price:amount"]',
+    "[itemprop=price]",
+    'meta[name="twitter:data1"]',
+  ]);
+
+  const currency = getAttr(doc, [
+    'meta[property="product:price:currency"]',
+    "[itemprop=priceCurrency]",
+  ]);
+
+  const brand = getAttr(doc, [
+    "[itemprop=brand]",
+    'meta[property="og:site_name"]',
+  ]) ||
+    getText(doc, [".product-brand", ".brand", "[data-brand]"]);
+
+  const availability =
+    getAttr(doc, ["[itemprop=availability]"]) ||
+    getText(doc, [".availability", ".stock", "[data-stock-status]"]);
+
+  return {
+    title,
+    image,
+    price,
+    currency,
+    brand,
+    availability,
+    retailer: retailerFromUrl(url) || undefined,
+    url,
+  } as AdapterProduct;
+}
+
+function getAttr(doc: Document, selectors: string[]): string | undefined {
+  for (const selector of selectors) {
+    const el = doc.querySelector(selector);
+    if (!el) continue;
+    const attr = el.getAttribute("content") || el.getAttribute("data-price") || el.getAttribute("value");
+    if (attr && attr.trim()) return attr.trim();
+    if (typeof HTMLMetaElement !== "undefined" && el instanceof HTMLMetaElement && el.content)
+      return el.content.trim();
+    if (typeof HTMLImageElement !== "undefined" && el instanceof HTMLImageElement && el.src)
+      return el.src.trim();
+    if (typeof HTMLAnchorElement !== "undefined" && el instanceof HTMLAnchorElement && el.href)
+      return el.href.trim();
+    if (el.textContent && el.textContent.trim()) return el.textContent.trim();
+  }
+  return undefined;
+}
+
+function getText(doc: Document, selectors: string[]): string | undefined {
+  for (const selector of selectors) {
+    const el = doc.querySelector(selector);
+    if (!el) continue;
+    const content = el.getAttribute("content") || el.textContent;
+    if (content && content.trim()) return content.trim();
+  }
+  return undefined;
+}
+
+function safeJsonParse(text: string): any | null {
+  try {
+    return JSON.parse(text);
+  } catch {
+    try {
+      const sanitized = text
+        .trim()
+        .replace(/^[^(\[{]*([\[{])/, "$1")
+        .replace(/([\]\}])[^\]\}]*$/, "$1");
+      return JSON.parse(sanitized);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function retailerFromUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.replace(/^www\./i, "");
+  } catch {
+    return null;
+  }
+}

--- a/app/api/chat/tools/index.ts
+++ b/app/api/chat/tools/index.ts
@@ -1,0 +1,744 @@
+// app/api/chat/tools/index.ts
+
+export type ToolName =
+  | "retailer_search"
+  | "stock_check"
+  | "affiliate_link"
+  | "palette_from_image"
+  | "fx_convert";
+
+export type ToolContext = {
+  /** User preferences passed from the chat UI */
+  preferences?: any;
+  /** Optional AbortSignal for downstream fetches */
+  signal?: AbortSignal;
+  /** Optional fetch implementation (defaults to global fetch) */
+  fetch?: typeof fetch;
+  /** Additional headers for network requests */
+  headers?: RequestInit["headers"];
+  /** Optional metadata passed through adapters */
+  meta?: Record<string, any>;
+};
+
+export interface SearchProductsArgs {
+  query: string;
+  country?: string;
+  currency?: string;
+  limit?: number;
+  budgetMax?: number;
+  size?: string;
+  category?: string;
+  color?: string;
+  /** Optional direct URL to inspect */
+  url?: string;
+}
+
+export interface CheckStockArgs {
+  productId: string;
+  country: string;
+  currency?: string;
+}
+
+export interface AffiliateLinkArgs {
+  url: string;
+  retailer?: string;
+}
+
+export interface PaletteFromImageArgs {
+  imageUrl: string;
+  swatches?: number;
+}
+
+export interface FxConvertArgs {
+  amount: number;
+  from: string;
+  to: string;
+  precision?: number;
+}
+
+export type AdapterProduct = {
+  id?: string;
+  sku?: string;
+  brand?: string | { name?: string } | { [key: string]: any };
+  name?: string;
+  title?: string;
+  description?: string;
+  price?: number | string;
+  priceText?: string;
+  priceAmount?: number | string;
+  priceValue?: number | string;
+  currency?: string;
+  priceCurrency?: string;
+  retailer?: string;
+  seller?: string | { name?: string };
+  store?: string;
+  vendor?: string;
+  merchant?: string;
+  url?: string;
+  link?: string;
+  href?: string;
+  productUrl?: string;
+  canonicalUrl?: string;
+  image?: string | string[];
+  imageUrl?: string;
+  image_url?: string;
+  imageHref?: string;
+  imageAlt?: string;
+  thumbnail?: string;
+  picture?: string;
+  gallery?: string[];
+  images?: string[];
+  color?: string;
+  colors?: string[] | string;
+  stock?: string | boolean | null;
+  availability?: string;
+  availabilityText?: string;
+  inStock?: boolean;
+  inventoryStatus?: string;
+  sizes?: string[] | string;
+  country?: string;
+  [key: string]: any;
+};
+
+export interface AdapterSearchResponse {
+  items: AdapterProduct[];
+  source: string;
+  latency: number;
+  meta?: Record<string, any>;
+}
+
+export interface SearchProductsResponse {
+  items: NormalizedProduct[];
+  source: string;
+  latency: number;
+  meta?: {
+    adapters: AdapterInvocationMeta[];
+    [key: string]: any;
+  };
+}
+
+export interface CheckStockResponse {
+  productId: string;
+  inStock: boolean | string | null;
+  price?: number;
+  currency?: string;
+  retailer?: string;
+  url?: string;
+  image?: string;
+  sizes?: string[];
+  source: string;
+  latency: number;
+  meta?: Record<string, any>;
+}
+
+export interface AffiliateLinkResponse {
+  url: string;
+  retailer?: string | null;
+  source: string;
+  latency: number;
+  meta?: Record<string, any>;
+}
+
+export interface PaletteFromImageResponse {
+  colors: string[];
+  source: string;
+  latency: number;
+  meta?: Record<string, any>;
+}
+
+export interface FxConvertResponse {
+  amount: number;
+  currency: string;
+  rate: number;
+  source: string;
+  latency: number;
+  meta?: Record<string, any>;
+}
+
+export interface ToolAdapter {
+  id: string;
+  searchProducts?: (
+    args: SearchProductsArgs,
+    ctx: ToolContext
+  ) => Promise<AdapterSearchResponse | null | undefined>;
+  checkStock?: (
+    args: CheckStockArgs,
+    ctx: ToolContext
+  ) => Promise<CheckStockResponse | null | undefined>;
+  affiliateLink?: (
+    args: AffiliateLinkArgs,
+    ctx: ToolContext
+  ) => Promise<AffiliateLinkResponse | null | undefined>;
+  paletteFromImage?: (
+    args: PaletteFromImageArgs,
+    ctx: ToolContext
+  ) => Promise<PaletteFromImageResponse | null | undefined>;
+  fxConvert?: (
+    args: FxConvertArgs,
+    ctx: ToolContext
+  ) => Promise<FxConvertResponse | null | undefined>;
+}
+
+export interface ToolDispatcher {
+  adapters: ToolAdapter[];
+  runTool<K extends ToolName>(
+    name: K,
+    args: ToolArguments[K],
+    ctx?: Partial<ToolContext>
+  ): Promise<ToolResponses[K]>;
+}
+
+export type ToolArguments = {
+  retailer_search: SearchProductsArgs;
+  stock_check: CheckStockArgs;
+  affiliate_link: AffiliateLinkArgs;
+  palette_from_image: PaletteFromImageArgs;
+  fx_convert: FxConvertArgs;
+};
+
+export type ToolResponses = {
+  retailer_search: SearchProductsResponse;
+  stock_check: CheckStockResponse;
+  affiliate_link: AffiliateLinkResponse;
+  palette_from_image: PaletteFromImageResponse;
+  fx_convert: FxConvertResponse;
+};
+
+export interface AdapterInvocationMeta {
+  source: string;
+  latency: number;
+  count?: number;
+  ok?: boolean;
+  error?: string;
+}
+
+export interface NormalizedProduct {
+  id?: string;
+  sku?: string;
+  brand?: string;
+  title: string;
+  description?: string;
+  price?: number;
+  currency?: string;
+  retailer?: string;
+  url: string;
+  link: string;
+  image?: string;
+  imageAlt?: string;
+  stock?: string | boolean | null;
+  sizes?: string[];
+  color?: string;
+  colors?: string[];
+  country?: string;
+  source: string;
+  raw?: AdapterProduct;
+}
+
+const DEFAULT_LIMIT = 12;
+
+export function createToolDispatcher(adapters: ToolAdapter[]): ToolDispatcher {
+  const activeAdapters = (adapters || []).filter(Boolean);
+
+  const runTool = async <K extends ToolName>(
+    name: K,
+    args: ToolArguments[K],
+    ctx?: Partial<ToolContext>
+  ): Promise<ToolResponses[K]> => {
+    const context = withDefaults(ctx);
+    switch (name) {
+      case "retailer_search":
+        return (await runSearch(
+          activeAdapters,
+          args as SearchProductsArgs,
+          context
+        )) as ToolResponses[K];
+      case "stock_check":
+        return (await runStock(
+          activeAdapters,
+          args as CheckStockArgs,
+          context
+        )) as ToolResponses[K];
+      case "affiliate_link":
+        return (await runAffiliate(
+          activeAdapters,
+          args as AffiliateLinkArgs,
+          context
+        )) as ToolResponses[K];
+      case "palette_from_image":
+        return (await runPalette(
+          activeAdapters,
+          args as PaletteFromImageArgs,
+          context
+        )) as ToolResponses[K];
+      case "fx_convert":
+        return (await runFx(
+          activeAdapters,
+          args as FxConvertArgs,
+          context
+        )) as ToolResponses[K];
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  };
+
+  return { adapters: activeAdapters, runTool };
+}
+
+async function runSearch(
+  adapters: ToolAdapter[],
+  args: SearchProductsArgs,
+  ctx: ToolContext
+): Promise<SearchProductsResponse> {
+  const limit = normalizeLimit(args?.limit ?? DEFAULT_LIMIT);
+  const collected: NormalizedProduct[] = [];
+  const meta: AdapterInvocationMeta[] = [];
+  const seen = new Set<string>();
+
+  for (const adapter of adapters) {
+    if (!adapter?.searchProducts) continue;
+    const started = Date.now();
+    try {
+      const res = await adapter.searchProducts(args, ctx);
+      const latency = res?.latency ?? Date.now() - started;
+      const source = res?.source || adapter.id;
+      const items = Array.isArray(res?.items) ? res!.items : [];
+      let accepted = 0;
+      for (const raw of items) {
+        const normalized = normalizeProduct(raw, {
+          source,
+          currency: args.currency,
+          retailer: raw?.retailer,
+        });
+        if (!normalized) continue;
+        const key = normalized.url;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        collected.push(normalized);
+        accepted += 1;
+        if (collected.length >= limit) break;
+      }
+      meta.push({ source, latency, count: accepted, ok: true });
+      if (collected.length >= limit) break;
+    } catch (err: any) {
+      meta.push({
+        source: adapter.id,
+        latency: Date.now() - started,
+        ok: false,
+        error: err?.message || "Adapter error",
+      });
+    }
+  }
+
+  const latencyTotal = meta.reduce((sum, m) => sum + (m.latency || 0), 0);
+
+  return {
+    items: collected.slice(0, limit),
+    source: meta.map((m) => m.source).join(" -> ") || "",
+    latency: latencyTotal,
+    meta: { adapters: meta },
+  };
+}
+
+async function runStock(
+  adapters: ToolAdapter[],
+  args: CheckStockArgs,
+  ctx: ToolContext
+): Promise<CheckStockResponse> {
+  for (const adapter of adapters) {
+    if (!adapter?.checkStock) continue;
+    const started = Date.now();
+    try {
+      const res = await adapter.checkStock(args, ctx);
+      if (!res) continue;
+      return {
+        ...res,
+        source: res.source || adapter.id,
+        latency: res.latency ?? Date.now() - started,
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  return {
+    productId: args.productId,
+    inStock: null,
+    source: "dispatcher",
+    latency: 0,
+  };
+}
+
+async function runAffiliate(
+  adapters: ToolAdapter[],
+  args: AffiliateLinkArgs,
+  ctx: ToolContext
+): Promise<AffiliateLinkResponse> {
+  for (const adapter of adapters) {
+    if (!adapter?.affiliateLink) continue;
+    const started = Date.now();
+    try {
+      const res = await adapter.affiliateLink(args, ctx);
+      if (!res) continue;
+      return {
+        ...res,
+        source: res.source || adapter.id,
+        latency: res.latency ?? Date.now() - started,
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  const fallbackRetailer = retailerFromUrl(args.url) || args.retailer || null;
+  return {
+    url: args.url,
+    retailer: fallbackRetailer,
+    source: "dispatcher",
+    latency: 0,
+  };
+}
+
+async function runPalette(
+  adapters: ToolAdapter[],
+  args: PaletteFromImageArgs,
+  ctx: ToolContext
+): Promise<PaletteFromImageResponse> {
+  for (const adapter of adapters) {
+    if (!adapter?.paletteFromImage) continue;
+    const started = Date.now();
+    try {
+      const res = await adapter.paletteFromImage(args, ctx);
+      if (!res) continue;
+      return {
+        ...res,
+        source: res.source || adapter.id,
+        latency: res.latency ?? Date.now() - started,
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  const colors = fallbackPalette(args.imageUrl, args.swatches);
+  return {
+    colors,
+    source: "dispatcher",
+    latency: 0,
+  };
+}
+
+async function runFx(
+  adapters: ToolAdapter[],
+  args: FxConvertArgs,
+  ctx: ToolContext
+): Promise<FxConvertResponse> {
+  for (const adapter of adapters) {
+    if (!adapter?.fxConvert) continue;
+    const started = Date.now();
+    try {
+      const res = await adapter.fxConvert(args, ctx);
+      if (!res) continue;
+      return {
+        ...res,
+        source: res.source || adapter.id,
+        latency: res.latency ?? Date.now() - started,
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  const { amount, currency, rate } = fallbackFx(args);
+  return {
+    amount,
+    currency,
+    rate,
+    source: "dispatcher",
+    latency: 0,
+  };
+}
+
+function withDefaults(ctx?: Partial<ToolContext>): ToolContext {
+  const fetcher = ctx?.fetch || (typeof fetch !== "undefined" ? fetch : undefined);
+  return {
+    ...ctx,
+    fetch: fetcher,
+  };
+}
+
+interface NormalizationDefaults {
+  source: string;
+  currency?: string;
+  retailer?: string;
+}
+
+function normalizeProduct(
+  raw: AdapterProduct,
+  defaults: NormalizationDefaults
+): NormalizedProduct | null {
+  const url = firstTruthy(
+    raw?.url,
+    raw?.productUrl,
+    raw?.canonicalUrl,
+    raw?.href,
+    raw?.link
+  );
+  if (!url || typeof url !== "string") return null;
+
+  const brand = normalizeBrand(raw?.brand);
+  const title = normalizeTitle(raw, brand);
+  const price = normalizePrice(raw?.price ?? raw?.priceAmount ?? raw?.priceValue ?? raw?.priceText);
+  const currency = normalizeCurrency(
+    raw?.currency || raw?.priceCurrency || defaults.currency
+  );
+
+  const retailer = normalizeRetailer(
+    raw?.retailer ||
+      sellerName(raw?.seller) ||
+      raw?.store ||
+      raw?.vendor ||
+      raw?.merchant ||
+      defaults.retailer ||
+      retailerFromUrl(url)
+  );
+
+  const image = normalizeImage(raw?.image, raw);
+  const stock = normalizeStock(raw);
+  const sizes = normalizeSizes(raw?.sizes);
+  const colors = normalizeColors(raw?.colors, raw?.color);
+
+  return {
+    id: raw?.id || raw?.productId || raw?.sku,
+    sku: raw?.sku,
+    brand: brand || undefined,
+    title,
+    description: typeof raw?.description === "string" ? raw.description : undefined,
+    price: price ?? undefined,
+    currency: currency || undefined,
+    retailer: retailer || undefined,
+    url,
+    link: url,
+    image: image || undefined,
+    imageAlt: typeof raw?.imageAlt === "string" ? raw.imageAlt : undefined,
+    stock,
+    sizes: sizes || undefined,
+    color: typeof raw?.color === "string" ? raw.color : undefined,
+    colors: colors || undefined,
+    country: raw?.country,
+    source: defaults.source,
+    raw,
+  };
+}
+
+function normalizeLimit(limit: number | undefined) {
+  if (!Number.isFinite(limit || NaN)) return DEFAULT_LIMIT;
+  const n = Math.floor(Number(limit));
+  return Math.min(Math.max(n, 1), 50);
+}
+
+function normalizeBrand(brand: AdapterProduct["brand"]): string | null {
+  if (!brand) return null;
+  if (typeof brand === "string") return brand.trim() || null;
+  if (typeof brand === "object") {
+    const name =
+      (brand as any).name ||
+      (brand as any)["@value"] ||
+      (brand as any)["@id"];
+    if (typeof name === "string") return name.trim() || null;
+  }
+  return null;
+}
+
+function normalizeTitle(raw: AdapterProduct, brand: string | null): string {
+  const candidates = [raw?.title, raw?.name, raw?.description];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  if (brand) return brand;
+  return "Product";
+}
+
+function normalizePrice(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string") return null;
+  const stripped = value.replace(/[^0-9.,-]/g, "");
+  if (!stripped) return null;
+  let normalized = stripped;
+  const commaCount = (normalized.match(/,/g) || []).length;
+  const dotCount = (normalized.match(/\./g) || []).length;
+  if (commaCount && dotCount) {
+    if (normalized.indexOf(",") > normalized.indexOf(".")) {
+      normalized = normalized.replace(/\./g, "").replace(/,/g, ".");
+    } else {
+      normalized = normalized.replace(/,/g, "");
+    }
+  } else if (commaCount && !dotCount) {
+    normalized = normalized.replace(/\./g, "").replace(/,/g, ".");
+  } else {
+    normalized = normalized.replace(/,/g, "");
+  }
+  const num = Number(normalized);
+  return Number.isFinite(num) ? num : null;
+}
+
+function normalizeCurrency(value: unknown): string | null {
+  if (!value) return null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.length === 1) {
+    if (trimmed === "€") return "EUR";
+    if (trimmed === "$") return "USD";
+    if (trimmed === "£") return "GBP";
+  }
+  if (/^[a-z]{3}$/i.test(trimmed)) return trimmed.toUpperCase();
+  return trimmed;
+}
+
+function normalizeRetailer(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.replace(/^www\./i, "");
+}
+
+function normalizeImage(image: AdapterProduct["image"], raw: AdapterProduct) {
+  if (!image) {
+    const candidates = [
+      raw?.imageUrl,
+      raw?.image_url,
+      raw?.imageHref,
+      raw?.thumbnail,
+      raw?.picture,
+    ];
+    for (const candidate of candidates) {
+      if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+    }
+    if (Array.isArray(raw?.images) && raw.images.length) {
+      const first = raw.images.find((it) => typeof it === "string" && it.trim());
+      if (first) return first.trim();
+    }
+    if (Array.isArray(raw?.gallery) && raw.gallery.length) {
+      const first = raw.gallery.find((it) => typeof it === "string" && it.trim());
+      if (first) return first.trim();
+    }
+    return undefined;
+  }
+  if (typeof image === "string") return image.trim();
+  if (Array.isArray(image)) {
+    const first = image.find((it) => typeof it === "string" && it.trim());
+    if (first) return first.trim();
+  }
+  return undefined;
+}
+
+function normalizeStock(raw: AdapterProduct): string | boolean | null | undefined {
+  if (typeof raw?.inStock === "boolean") return raw.inStock;
+  const availability =
+    raw?.stock ??
+    raw?.availability ??
+    raw?.availabilityText ??
+    raw?.inventoryStatus;
+  if (typeof availability === "boolean") return availability;
+  if (availability == null) return undefined;
+  if (typeof availability === "string") {
+    const lower = availability.toLowerCase();
+    if (/(pre[-\s]?order)/.test(lower)) return "preorder";
+    if (/(instock|in\s?stock|available)/.test(lower)) return true;
+    if (/(outofstock|out\s?of\s?stock|sold\s?out)/.test(lower)) return false;
+    return availability;
+  }
+  return undefined;
+}
+
+function normalizeSizes(value: AdapterProduct["sizes"]): string[] | undefined {
+  if (!value) return undefined;
+  if (Array.isArray(value)) {
+    return value.map((v) => (typeof v === "string" ? v.trim() : String(v))).filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value
+      .split(/[,/|]/)
+      .map((v) => v.trim())
+      .filter(Boolean);
+  }
+  return undefined;
+}
+
+function normalizeColors(colors: AdapterProduct["colors"], color?: string) {
+  const arr: string[] = [];
+  if (Array.isArray(colors)) {
+    colors.forEach((c) => {
+      if (typeof c === "string" && c.trim()) arr.push(c.trim());
+    });
+  } else if (typeof colors === "string") {
+    colors
+      .split(/[,/|]/)
+      .map((c) => c.trim())
+      .filter(Boolean)
+      .forEach((c) => arr.push(c));
+  }
+  if (typeof color === "string" && color.trim()) arr.push(color.trim());
+  return arr.length ? Array.from(new Set(arr)) : undefined;
+}
+
+function firstTruthy<T>(...values: T[]): T | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value;
+    if (value) return value;
+  }
+  return null;
+}
+
+function sellerName(seller: AdapterProduct["seller"]): string | null {
+  if (!seller) return null;
+  if (typeof seller === "string") return seller;
+  if (typeof seller === "object") {
+    const name = (seller as any).name || (seller as any)["@value"];
+    if (typeof name === "string") return name;
+  }
+  return null;
+}
+
+function retailerFromUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.replace(/^www\./i, "");
+  } catch {
+    return null;
+  }
+}
+
+function fallbackPalette(imageUrl: string, swatches = 5): string[] {
+  const base = ["#2E2E2E", "#7F7F7F", "#EAE7E2", "#C7A27A", "#4A646C", "#B0C2C1", "#252A34"];
+  const count = Math.max(1, Math.min(swatches || base.length, base.length));
+  if (!imageUrl) return base.slice(0, count);
+  let hash = 0;
+  for (let i = 0; i < imageUrl.length; i += 1) {
+    hash = (hash * 31 + imageUrl.charCodeAt(i)) % base.length;
+  }
+  const rotated = [...base.slice(hash), ...base.slice(0, hash)];
+  return rotated.slice(0, count);
+}
+
+function fallbackFx(args: FxConvertArgs) {
+  const from = args?.from ? args.from.toUpperCase() : "EUR";
+  const to = args?.to ? args.to.toUpperCase() : "EUR";
+  const amount = Number(args?.amount ?? 0) || 0;
+  const precision = Number.isFinite(args?.precision || NaN)
+    ? Math.max(0, Math.min(4, Math.floor(Number(args.precision))))
+    : 2;
+
+  const matrix: Record<string, Record<string, number>> = {
+    EUR: { USD: 1.08, GBP: 0.86, EUR: 1 },
+    USD: { EUR: 0.93, GBP: 0.80, USD: 1 },
+    GBP: { EUR: 1.16, USD: 1.24, GBP: 1 },
+  };
+
+  const rate = matrix[from]?.[to] ?? 1;
+  const converted = Number((amount * rate).toFixed(precision));
+
+  return { amount: converted, currency: to, rate };
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,12 @@
 {
   "compilerOptions": {
-    "target": "ES2017",                 // was "es5"
-    "lib": ["dom", "dom.iterable", "es2017"],
-    "downlevelIteration": true,         // allow for..of / spread on Set/Map if ever downleveled
+    "target": "ES2017", // was "es5"
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2017"
+    ],
+    "downlevelIteration": true, // allow for..of / spread on Set/Map if ever downleveled
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -16,8 +20,24 @@
     "jsx": "preserve",
     "incremental": true,
     "baseUrl": ".",
-    "paths": { "@/*": ["./*"] }
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- introduce a shared tool dispatcher and normalization pipeline for chat tools
- add demo, web-scraping, and AWIN adapters that plug into the dispatcher
- update the chat route to use the new adapters and enrich optimistic drafts
- expose new tool schemas and enable currency conversion utility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bfef55448324ab6cdc87503afba8