### PR TITLE
Align product types, normalize categories, and fix build errors

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -767,7 +767,7 @@ export async function POST(req: NextRequest) {
       "- `why` must include a wearability check and, if natural, one gentle adjustment suggestion.",
       "- Choose links ONLY from CANDIDATE_LINKS (copy URL exactly). If nothing fits, return an empty products array.",
       "- If a candidate provides category/brand/price/currency/image/retailer/availability, reuse those values. Do NOT invent them.",
-      "- Do NOT invent products. If nothing meets the standard, return an empty products array.",
+      "- Do NOT invent products. If nothing fits, return an empty products array.",
       "- Do NOT invent exact prices. If missing, omit the product entirely.",
       "- Never include markdown, commentary, or extra keys.",
       "- Avoid generic filler phrases. Write with fashion intelligence and restraint.",

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -49,10 +49,11 @@ type PlanJson = {
 };
 
 const MODEL = process.env.OPENAI_MODEL || "gpt-4o-mini";
-const HAS_KEY = Boolean(process.env.OPENAI_API_KEY);
+const apiKey = process.env.OPENAI_API_KEY;
+const HAS_KEY = Boolean(apiKey);
 const ALLOW_WEB = (process.env.ALLOW_WEB || "true").toLowerCase() !== "false";
 
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const client = apiKey ? new OpenAI({ apiKey }) : null;
 
 function contentToText(c: unknown): string {
   if (typeof c === "string") return c;
@@ -485,7 +486,7 @@ export async function POST(req: NextRequest) {
     const currency = currencyFor(preferences);
     let plan: PlanJson | null = null;
 
-    if (HAS_KEY) {
+    if (HAS_KEY && client) {
       try {
         const completion = await client.chat.completions.create({
           model: MODEL,

--- a/app/api/chat/systemPrompt.ts
+++ b/app/api/chat/systemPrompt.ts
@@ -35,9 +35,8 @@ RULES:
 - Use candidate product data when available; do NOT invent domains or fake URLs.
 - If no candidates: choose best matches from the provided local catalog (you *will* receive those candidates from the system).
 - Use EUR unless specified otherwise.
-- `brief` should be 2–4 sentences: interpret the brief first, then state the aesthetic direction in plain language.
-- `tips` should talk through the outfit decisions one item at a time (why each piece, not just a list).
-- `why` should include a wearability check and, if natural, one gentle adjustment suggestion.
+- 'brief' should be 2–4 sentences: interpret the brief first, then state the aesthetic direction in plain language.
+- 'tips' should talk through the outfit decisions one item at a time (why each piece, not just a list).
+- 'why' should include a wearability check and, if natural, one gentle adjustment suggestion.
 - Respond with valid JSON only. No markdown backticks, no headings, no commentary.
 `.trim();
-

--- a/app/api/chat/systemPrompt.ts
+++ b/app/api/chat/systemPrompt.ts
@@ -3,7 +3,9 @@
 // Strict schema, no markdown, no extra prose.
 
 export const STYLIST_SYSTEM_PROMPT = `
-You are RunwayTwin, an editorial-caliber personal stylist.
+You are RunwayTwin, a professional personal stylist.
+Never describe yourself as an AI, shopping assistant, or product recommender.
+Speak like a human stylist: warm, confident, opinionated, conversational.
 
 OUTPUT FORMAT (STRICT JSON ONLY):
 {
@@ -33,7 +35,9 @@ RULES:
 - Use candidate product data when available; do NOT invent domains or fake URLs.
 - If no candidates: choose best matches from the provided local catalog (you *will* receive those candidates from the system).
 - Use EUR unless specified otherwise.
+- `brief` should be 2–4 sentences: interpret the brief first, then state the aesthetic direction in plain language.
+- `tips` should talk through the outfit decisions one item at a time (why each piece, not just a list).
+- `why` should include a wearability check and, if natural, one gentle adjustment suggestion.
 - Respond with valid JSON only. No markdown backticks, no headings, no commentary.
 `.trim();
-
 

--- a/app/api/look/[jobId]/debug/route.ts
+++ b/app/api/look/[jobId]/debug/route.ts
@@ -1,4 +1,4 @@
-// FILE: app/api/look/[jobId]/route.ts
+// FILE: app/api/look/[jobId]/debug/route.ts
 export const runtime = "nodejs";
 
 import { NextRequest } from "next/server";
@@ -29,6 +29,11 @@ export async function GET(_req: NextRequest, ctx: { params: { jobId: string } })
     JSON.stringify({
       ok: true,
       status: job.status,
+      progress: job.progress,
+      errors: job.errors,
+      logs: job.logs,
+      updated_at: job.updatedAt,
+      created_at: job.createdAt,
       result: job.result,
     }),
     { headers }

--- a/app/api/look/[jobId]/route.ts
+++ b/app/api/look/[jobId]/route.ts
@@ -1,0 +1,30 @@
+// FILE: app/api/look/[jobId]/route.ts
+export const runtime = "nodejs";
+
+import { NextRequest } from "next/server";
+import { getJob } from "@/lib/style/store";
+
+export async function GET(_req: NextRequest, ctx: { params: { jobId: string } }) {
+  const headers = new Headers({
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+
+  const jobId = ctx.params.jobId;
+  const job = getJob(jobId);
+  if (!job) {
+    return new Response(JSON.stringify({ ok: false, error: "Job not found." }), {
+      status: 404,
+      headers,
+    });
+  }
+
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      status: job.status,
+      result: job.result,
+    }),
+    { headers }
+  );
+}

--- a/app/api/look/[jobId]/route.ts
+++ b/app/api/look/[jobId]/route.ts
@@ -25,10 +25,20 @@ export async function GET(_req: NextRequest, ctx: { params: { jobId: string } })
     void runLookJob(job.plan);
   }
 
+  const productsBySlot = (job.result?.slots || []).reduce((acc, p) => {
+    acc[p.slot] = acc[p.slot] ? [...acc[p.slot], p] : [p];
+    return acc;
+  }, {} as Record<string, typeof job.result.slots>);
+
   return new Response(
     JSON.stringify({
       ok: true,
       status: job.status,
+      progress: job.progress,
+      productsBySlot,
+      stylist_text_final: job.result?.message ?? null,
+      startedAt: job.createdAt,
+      updatedAt: job.updatedAt,
       result: job.result,
     }),
     { headers }

--- a/app/api/look/route.ts
+++ b/app/api/look/route.ts
@@ -1,0 +1,43 @@
+// FILE: app/api/look/route.ts
+export const runtime = "nodejs";
+
+import { NextRequest } from "next/server";
+import type { StylePlan } from "@/lib/style/types";
+import { cacheKey, getCached, makeJob, updateJob } from "@/lib/style/store";
+import { runLookJob } from "@/lib/style/worker";
+
+export async function POST(req: NextRequest) {
+  const headers = new Headers({
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+
+  if (!(req.headers.get("content-type") || "").includes("application/json")) {
+    return new Response(JSON.stringify({ ok: false, error: "Expected application/json." }), {
+      status: 415,
+      headers,
+    });
+  }
+
+  const body = (await req.json().catch(() => ({}))) as { plan?: StylePlan };
+  const plan = body.plan;
+  if (!plan) {
+    return new Response(JSON.stringify({ ok: false, error: "Missing StylePlan." }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  const cached = getCached(cacheKey(plan));
+  if (cached) {
+    return new Response(JSON.stringify({ ok: true, job_id: cached.look_id, cached: true }), {
+      headers,
+    });
+  }
+
+  const job = makeJob(plan);
+  updateJob(job.id, { status: "running" });
+  void runLookJob(plan);
+
+  return new Response(JSON.stringify({ ok: true, job_id: job.id }), { headers });
+}

--- a/app/api/products/search/route.ts
+++ b/app/api/products/search/route.ts
@@ -109,6 +109,23 @@ export async function POST(req: Request) {
     .map((p) => toStrictProduct(p))
     .filter((p): p is StrictProduct => Boolean(p));
 
+  if (!strictItems.length) {
+    return NextResponse.json(
+      {
+        ok: false,
+        count: 0,
+        query: q,
+        items: [],
+        error: "No verified products available for this query.",
+        meta: {
+          providers: selected,
+          filteredByPrice: hasMin || hasMax ? { min: body.priceMin, max: body.priceMax } : null,
+        },
+      },
+      { status: 200 }
+    );
+  }
+
   return NextResponse.json(
     {
       ok: true,

--- a/app/api/products/search/route.ts
+++ b/app/api/products/search/route.ts
@@ -8,6 +8,7 @@ import { awinProvider } from "@/lib/affiliates/providers/awin";
 import { webProvider } from "@/lib/affiliates/providers/web";
 import { wrapProducts } from "@/lib/affiliates/linkWrapper";
 import { rankProducts } from "@/lib/affiliates/ranker";
+import { toStrictProduct, type StrictProduct } from "@/lib/affiliates/validate";
 import type { Product, ProviderKey } from "@/lib/affiliates/types";
 import type { Prefs } from "@/lib/types";
 
@@ -104,13 +105,16 @@ export async function POST(req: Request) {
 
   // Rank with query + prefs
   const ranked = rankProducts({ products: merged, query: q, prefs }).slice(0, overall);
+  const strictItems: StrictProduct[] = ranked
+    .map((p) => toStrictProduct(p))
+    .filter((p): p is StrictProduct => Boolean(p));
 
   return NextResponse.json(
     {
       ok: true,
-      count: ranked.length,
+      count: strictItems.length,
       query: q,
-      items: ranked,
+      items: strictItems,
       meta: {
         providers: selected,
         filteredByPrice: hasMin || hasMax ? { min: body.priceMin, max: body.priceMax } : null,
@@ -119,4 +123,3 @@ export async function POST(req: Request) {
     { status: 200 }
   );
 }
-

--- a/app/api/products/search/route.ts
+++ b/app/api/products/search/route.ts
@@ -32,6 +32,28 @@ function isProviderKey(x: unknown): x is ProviderKey {
   return x === "web" || x === "amazon" || x === "rakuten" || x === "awin";
 }
 
+function regionAllowlist(country?: string): string[] {
+  const code = (country || "").trim().toUpperCase();
+  if (!code) return [];
+  if (code === "US") {
+    return ["amazon.com", "shopbop.com", "nordstrom.com", "ssense.com", "net-a-porter.com"];
+  }
+  if (code === "GB" || code === "UK") {
+    return ["net-a-porter.com", "mrporter.com", "selfridges.com", "matchesfashion.com"];
+  }
+  return [];
+}
+
+function hostAllowed(url: string, list: string[]): boolean {
+  if (!list.length) return true;
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, "").toLowerCase();
+    return list.some((d) => host === d || host.endsWith(`.${d}`));
+  } catch {
+    return false;
+  }
+}
+
 export async function POST(req: Request) {
   const ct = req.headers.get("content-type") || "";
   if (!ct.includes("application/json")) return bad("Expected application/json", 415);

--- a/app/api/say/route.ts
+++ b/app/api/say/route.ts
@@ -51,17 +51,18 @@ export async function POST(req: NextRequest) {
     const history: ChatMessage[] = Array.isArray(body?.messages) ? body!.messages! : [];
 
     const sys =
-      "You are a warm, concise fashion stylist. When the user is just chatting, respond in 1–2 short sentences and, if natural, ask one polite follow-up about their style or upcoming plans. Do not output lists, markdown headings, or JSON unless explicitly asked.";
+      "You are RunwayTwin, a professional personal stylist. Not an AI. Not a shopping assistant. Not a product recommender. Respond in 2–4 short, warm sentences, and if natural ask one polite follow-up about their style or upcoming plans. Keep it conversational and human. Do not output lists, markdown headings, or JSON unless explicitly asked.";
 
     if (!HAS_KEY) {
-      return new Response("Hi! I’m good — excited to style your next look. What occasion are you dressing for?", {
-        headers,
-      });
+      return new Response(
+        "Hi — I’m good, and I’m glad you’re here. Tell me what you’re dressing for and how you want to feel in it.",
+        { headers }
+      );
     }
 
     if (!client) {
       return new Response(
-        "Hi! I’m good — excited to style your next look. What occasion are you dressing for?",
+        "Hi — I’m good, and I’m glad you’re here. Tell me what you’re dressing for and how you want to feel in it.",
         { headers }
       );
     }

--- a/app/api/say/route.ts
+++ b/app/api/say/route.ts
@@ -5,8 +5,9 @@ import OpenAI from "openai";
 import { NextRequest } from "next/server";
 
 const MODEL = process.env.OPENAI_MODEL || "gpt-4o-mini";
-const HAS_KEY = Boolean(process.env.OPENAI_API_KEY);
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const apiKey = process.env.OPENAI_API_KEY;
+const HAS_KEY = Boolean(apiKey);
+const client = apiKey ? new OpenAI({ apiKey }) : null;
 
 type Role = "system" | "user" | "assistant";
 type ChatMessage = { role: Role; content: string | unknown[] };
@@ -56,6 +57,13 @@ export async function POST(req: NextRequest) {
       return new Response("Hi! I’m good — excited to style your next look. What occasion are you dressing for?", {
         headers,
       });
+    }
+
+    if (!client) {
+      return new Response(
+        "Hi! I’m good — excited to style your next look. What occasion are you dressing for?",
+        { headers }
+      );
     }
 
     const completion = await client.chat.completions.create({

--- a/app/api/styleplan/route.ts
+++ b/app/api/styleplan/route.ts
@@ -1,0 +1,159 @@
+// FILE: app/api/styleplan/route.ts
+export const runtime = "nodejs";
+
+import OpenAI from "openai";
+import { NextRequest } from "next/server";
+import type { StylePlan, SlotName } from "@/lib/style/types";
+
+type Prefs = {
+  gender?: string;
+  bodyType?: string;
+  budget?: string;
+  country?: string;
+  keywords?: string[];
+  sizes?: { top?: string; bottom?: string; dress?: string; shoe?: string };
+};
+
+const MODEL = process.env.OPENAI_MODEL || "gpt-4o-mini";
+const HAS_KEY = Boolean(process.env.OPENAI_API_KEY);
+const client = HAS_KEY ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY }) : null;
+
+function parseBudget(input?: string): number {
+  if (!input) return 400;
+  const nums = Array.from(input.matchAll(/\d+(?:[.,]\d+)?/g)).map((m) =>
+    Number(m[0].replace(",", "."))
+  );
+  if (!nums.length) return 400;
+  const max = Math.max(...nums);
+  return Number.isFinite(max) ? Math.max(150, max) : 400;
+}
+
+function defaultPlan(prompt: string, prefs: Prefs): StylePlan {
+  const budget = parseBudget(prefs.budget);
+  const currency = prefs.country?.toUpperCase() === "US" ? "USD" : "EUR";
+  const slots: SlotName[] = ["anchor", "top", "bottom", "shoe", "accessory"];
+  const lookId = crypto.randomUUID();
+  return {
+    look_id: lookId,
+    aesthetic_read: "Clean, intentional minimalism with a polished line.",
+    vibe_keywords: ["clean", "polished", "modern", "intentional"],
+    required_slots: slots,
+    per_slot: slots.map((slot) => ({
+      slot,
+      category: slot === "shoe" ? "Shoes" : slot === "accessory" ? "Accessory" : "Apparel",
+      keywords: [slot, ...(prefs.keywords ?? [])].filter(Boolean),
+      allowed_colors: ["black", "cream", "navy", "camel"],
+      banned_materials: ["polyurethane"],
+      min_price: Math.round(budget * 0.08),
+      max_price: Math.round(budget * 0.35),
+    })),
+    budget_split: slots.map((slot) => ({
+      slot,
+      min: Math.round(budget * 0.08),
+      max: Math.round(budget * 0.35),
+    })),
+    retailer_priority: prefs.country?.toUpperCase() === "US"
+      ? ["COS", "Zara", "& Other Stories"]
+      : ["COS", "& Other Stories", "Zara"],
+    search_queries: slots.map((slot) => ({
+      slot,
+      query: `${prompt} ${slot}`.trim(),
+    })),
+    budget_total: budget,
+    currency,
+    allow_stretch: false,
+    preferences: {
+      gender: prefs.gender,
+      body_type: prefs.bodyType,
+      budget: prefs.budget,
+      country: prefs.country,
+      keywords: prefs.keywords,
+      sizes: prefs.sizes,
+      prompt,
+    },
+  };
+}
+
+export async function POST(req: NextRequest) {
+  const headers = new Headers({
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+
+  if (!(req.headers.get("content-type") || "").includes("application/json")) {
+    return new Response(JSON.stringify({ ok: false, error: "Expected application/json." }), {
+      status: 415,
+      headers,
+    });
+  }
+
+  const body = (await req.json().catch(() => ({}))) as {
+    prompt?: string;
+    prefs?: Prefs;
+  };
+  const prompt = (body.prompt || "").trim();
+  const prefs = body.prefs || {};
+
+  if (!prompt) {
+    return new Response(JSON.stringify({ ok: false, error: "Missing prompt." }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  if (!HAS_KEY || !client) {
+    const plan = defaultPlan(prompt, prefs);
+    return new Response(JSON.stringify({ ok: true, plan }), { headers });
+  }
+
+  const sys = [
+    "You are RunwayTwin, a professional personal stylist.",
+    "Return ONLY valid JSON.",
+    "Create a StylePlan object with this shape:",
+    "{ aesthetic_read: string, vibe_keywords: string[], required_slots: string[], per_slot: { slot: string, category: string, keywords: string[], allowed_colors: string[], banned_materials: string[], min_price: number, max_price: number }[], budget_split: { slot: string, min: number, max: number }[], retailer_priority: string[], search_queries: { slot: string, query: string }[] }",
+    "Rules:",
+    "- No web calls, no scraping. Pure reasoning.",
+    "- Respect the budget, body type, and region.",
+    "- Slots should include anchor, top, bottom, shoe, accessory unless user asks for dress-only.",
+    "- Keep keyword arrays short and concrete.",
+  ].join("\n");
+
+  try {
+    const completion = await client.chat.completions.create({
+      model: MODEL,
+      temperature: 0.4,
+      response_format: { type: "json_object" },
+      messages: [
+        { role: "system", content: sys },
+        {
+          role: "user",
+          content: JSON.stringify({
+            prompt,
+            prefs,
+            budget_total: parseBudget(prefs.budget),
+            currency: prefs.country?.toUpperCase() === "US" ? "USD" : "EUR",
+          }),
+        },
+      ],
+    });
+
+    const raw = completion.choices?.[0]?.message?.content || "{}";
+    const parsed = JSON.parse(raw) as Partial<StylePlan>;
+    const lookId = crypto.randomUUID();
+    const fallback = defaultPlan(prompt, prefs);
+    const plan: StylePlan = {
+      ...fallback,
+      ...parsed,
+      look_id: lookId,
+      budget_total: parseBudget(prefs.budget),
+      currency: prefs.country?.toUpperCase() === "US" ? "USD" : "EUR",
+      allow_stretch: Boolean((parsed as any).allow_stretch ?? false),
+      preferences: { ...fallback.preferences, prompt },
+    };
+
+    return new Response(JSON.stringify({ ok: true, plan }), { headers });
+  } catch {
+    const plan = defaultPlan(prompt, prefs);
+    return new Response(JSON.stringify({ ok: true, plan }), { headers });
+  }
+}

--- a/app/api/styleplan/route.ts
+++ b/app/api/styleplan/route.ts
@@ -137,7 +137,7 @@ export async function POST(req: NextRequest) {
 
   if (!HAS_KEY || !client) {
     const plan = defaultPlan(prompt, prefs);
-    return new Response(JSON.stringify({ ok: true, plan }), { headers });
+    return new Response(JSON.stringify({ ok: true, stylePlan: plan, stylist_script: plan.stylist_script }), { headers });
   }
 
   const sys = [
@@ -187,9 +187,9 @@ export async function POST(req: NextRequest) {
       preferences: { ...fallback.preferences, prompt },
     };
 
-    return new Response(JSON.stringify({ ok: true, plan }), { headers });
+    return new Response(JSON.stringify({ ok: true, stylePlan: plan, stylist_script: plan.stylist_script }), { headers });
   } catch {
     const plan = defaultPlan(prompt, prefs);
-    return new Response(JSON.stringify({ ok: true, plan }), { headers });
+    return new Response(JSON.stringify({ ok: true, stylePlan: plan, stylist_script: plan.stylist_script }), { headers });
   }
 }

--- a/app/api/stylist/route.ts
+++ b/app/api/stylist/route.ts
@@ -9,16 +9,29 @@ export async function POST(req: Request) {
     const { message, prefs } = await req.json();
 
     const systemPrompt = `
-You are RunwayTwin — an AI celebrity stylist. Your tone: confident, editorial, concise.
-Given: a muse (celebrity) + occasion + preferences.
-Return: a shoppable outfit idea (top, bottom, shoes, accessory), including a short reasoning (fit, palette, texture).
+You are RunwayTwin, a professional personal stylist. Not an AI. Not a shopping assistant. Not a product recommender.
+Speak like a human stylist in a fitting room: warm, confident, opinionated, conversational. Think out loud.
+
+REQUIRED RESPONSE FLOW (MANDATORY ORDER)
+1) Stylist opening (2–4 sentences): show you understood the brief and constraints.
+2) Aesthetic direction: one plain-language line.
+3) Build the outfit, one decision at a time (talk through each choice and why).
+4) Only include products you are confident are purchasable and link to the exact product page.
+5) Total + wearability check.
+6) Gentle stylist adjustment (optional, one natural suggestion).
+
+Language rules:
+- Do NOT mention being an AI or assistant.
+- Never use "inventory is thin".
+- Avoid hypey, salesy language.
 
 User prefs:
 ${JSON.stringify(prefs, null, 2)}
 `;
 
     if (!client) {
-      const fallback = "Mock reply: Add a sleek blazer, straight-leg trousers, and minimalist sneakers.";
+      const fallback =
+        "Okay — I’m with you. Give me the occasion and your budget, and I’ll build this out step by step.";
       return NextResponse.json({ reply: fallback }, { status: 200 });
     }
 

--- a/app/api/stylist/route.ts
+++ b/app/api/stylist/route.ts
@@ -1,7 +1,8 @@
 import OpenAI from "openai";
 import { NextResponse } from "next/server";
 
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const apiKey = process.env.OPENAI_API_KEY;
+const client = apiKey ? new OpenAI({ apiKey }) : null;
 
 export async function POST(req: Request) {
   try {
@@ -15,6 +16,11 @@ Return: a shoppable outfit idea (top, bottom, shoes, accessory), including a sho
 User prefs:
 ${JSON.stringify(prefs, null, 2)}
 `;
+
+    if (!client) {
+      const fallback = "Mock reply: Add a sleek blazer, straight-leg trousers, and minimalist sneakers.";
+      return NextResponse.json({ reply: fallback }, { status: 200 });
+    }
 
     const completion = await client.chat.completions.create({
       model: "gpt-4o-mini",

--- a/app/api/stylist/route.ts
+++ b/app/api/stylist/route.ts
@@ -22,7 +22,6 @@ REQUIRED RESPONSE FLOW (MANDATORY ORDER)
 
 Language rules:
 - Do NOT mention being an AI or assistant.
-- Never use "inventory is thin".
 - Avoid hypey, salesy language.
 
 User prefs:

--- a/app/stylist/page.tsx
+++ b/app/stylist/page.tsx
@@ -42,12 +42,62 @@ type UiProduct = {
   image: string | null;
 };
 
-type AiJson = {
-  brief: string;
-  tips: string[];
-  why: string[];
-  products: UiProduct[];
-  total: { value: number | null; currency: string };
+type SlotName = "anchor" | "top" | "bottom" | "dress" | "shoe" | "accessory";
+
+type StylePlan = {
+  look_id: string;
+  aesthetic_read: string;
+  vibe_keywords: string[];
+  required_slots: SlotName[];
+  per_slot: Array<{
+    slot: SlotName;
+    category: string;
+    keywords: string[];
+    allowed_colors: string[];
+    banned_materials: string[];
+    min_price: number;
+    max_price: number;
+  }>;
+  budget_split: Array<{ slot: SlotName; min: number; max: number }>;
+  retailer_priority: string[];
+  search_queries: Array<{ slot: SlotName; query: string }>;
+  budget_total: number;
+  currency: string;
+  allow_stretch: boolean;
+  preferences: {
+    gender?: string;
+    body_type?: string;
+    budget?: string;
+    country?: string;
+    keywords?: string[];
+    sizes?: { top?: string; bottom?: string; dress?: string; shoe?: string };
+    prompt?: string;
+  };
+};
+
+type LookProduct = {
+  id: string;
+  retailer: string;
+  brand: string;
+  title: string;
+  price: number;
+  currency: string;
+  image_url: string;
+  product_url: string;
+  availability: "in_stock" | "out_of_stock" | "unknown";
+  slot: SlotName;
+  category: string;
+};
+
+type LookResponse = {
+  look_id: string;
+  status: "pending" | "running" | "partial" | "complete" | "failed";
+  message: string;
+  slots: LookProduct[];
+  total_price: number | null;
+  currency: string;
+  missing_slots: SlotName[];
+  note?: string;
 };
 
 /* ===================== UI atoms/helpers ===================== */
@@ -83,22 +133,10 @@ function proxyImage(src: string | null): string | null {
   }
 }
 
-/* ================== JSON coercion (matches /api/chat) ================== */
+/* ================== Style helpers ================== */
 
-function isObj(x: unknown): x is Record<string, unknown> {
-  return typeof x === "object" && x !== null;
-}
-
-function asString(x: unknown, def = ""): string {
-  return typeof x === "string" ? x : def;
-}
-
-function asNumberOrNull(x: unknown): number | null {
-  return typeof x === "number" && Number.isFinite(x) ? x : null;
-}
-
-function normalizeCategory(raw: unknown): UiCategory {
-  const v = typeof raw === "string" ? raw.toLowerCase() : "";
+function normalizeCategory(raw: string): UiCategory {
+  const v = raw.toLowerCase();
   if (v.includes("dress")) return "Dress";
   if (v.includes("coat") || v.includes("jacket") || v.includes("trench"))
     return "Outerwear";
@@ -112,113 +150,28 @@ function normalizeCategory(raw: unknown): UiCategory {
   return "Accessory";
 }
 
-function asProduct(x: unknown, fallbackCurrency: string): UiProduct | null {
-  if (!isObj(x)) return null;
-
-  const id = asString(x["id"], "");
-  const title = asString(x["title"], "");
-  if (!title) return null;
-
-  const url =
-    typeof x["url"] === "string" && x["url"].trim().length
-      ? (x["url"] as string)
-      : null;
-
-  const brand =
-    typeof x["brand"] === "string" && x["brand"].trim().length
-      ? (x["brand"] as string)
-      : null;
-
-  const cat = normalizeCategory(x["category"]);
-  const price = asNumberOrNull(x["price"]);
-
-  const currency =
-    typeof x["currency"] === "string" && x["currency"].trim().length
-      ? (x["currency"] as string)
-      : fallbackCurrency;
-
-  const image =
-    typeof x["image"] === "string" && x["image"].trim().length
-      ? (x["image"] as string)
-      : null;
-
-  const affiliateUrl =
-    typeof x["affiliate_url"] === "string" && x["affiliate_url"].trim().length
-      ? (x["affiliate_url"] as string)
-      : url;
-
-  const retailer =
-    typeof x["retailer"] === "string" && x["retailer"].trim().length
-      ? (x["retailer"] as string)
-      : null;
-
-  const availability =
-    typeof x["availability"] === "string" && x["availability"].trim().length
-      ? (x["availability"] as string)
-      : null;
-
-  return {
-    id: id || (url ?? title),
-    title,
-    url,
-    brand,
-    affiliate_url: affiliateUrl,
-    retailer,
-    availability,
-    category: cat,
-    price,
-    currency,
-    image,
-  };
+function buildPhaseOneMessage(prompt: string, plan: StylePlan): string {
+  const opening = `Okay — ${prompt}. I’m taking your budget and constraints seriously, but I still want this to feel intentional.`;
+  const direction = `We’re going for ${plan.aesthetic_read.toLowerCase()}.`;
+  const keywords = plan.vibe_keywords.length
+    ? `Think ${plan.vibe_keywords.slice(0, 4).join(", ")}.`
+    : "Think clean lines and quiet structure.";
+  return [opening, direction, keywords].join(" ");
 }
 
-function coerceAiJson(content: string): AiJson | null {
-  let raw: unknown;
-  try {
-    raw = JSON.parse(content);
-  } catch {
-    return null;
-  }
-  if (!isObj(raw)) return null;
-
-  const brief = asString(raw["brief"], "");
-  const tips = Array.isArray(raw["tips"])
-    ? ((raw["tips"] as unknown[]).filter((s) => typeof s === "string") as string[])
-    : [];
-  const why = Array.isArray(raw["why"])
-    ? ((raw["why"] as unknown[]).filter((s) => typeof s === "string") as string[])
-    : [];
-
-  const productsRaw = Array.isArray(raw["products"])
-    ? (raw["products"] as unknown[])
-    : [];
-  const fallbackCurrency =
-    (isObj(raw["total"]) &&
-      typeof raw["total"]["currency"] === "string" &&
-      raw["total"]["currency"]) ||
-    "EUR";
-
-  const products: UiProduct[] = productsRaw
-    .map((p) => asProduct(p, fallbackCurrency))
-    .filter((p): p is UiProduct => !!p);
-
-  const totalObj = isObj(raw["total"])
-    ? (raw["total"] as Record<string, unknown>)
-    : {};
-  const totalCurrency =
-    typeof totalObj["currency"] === "string"
-      ? (totalObj["currency"] as string)
-      : fallbackCurrency;
-  const totalValue = asNumberOrNull(totalObj["value"]);
-
-  if (!brief && !tips.length && !why.length && !products.length) return null;
-
+function toUiProduct(item: LookProduct): UiProduct {
   return {
-    brief,
-    tips,
-    why,
-    products,
-    total: { value: totalValue, currency: totalCurrency },
+    id: item.id,
+    title: item.title,
+    url: item.product_url,
+    brand: item.brand,
+    affiliate_url: item.product_url,
+    retailer: item.retailer,
+    availability: item.availability,
+    category: normalizeCategory(item.category),
+    price: item.price,
+    currency: item.currency,
+    image: item.image_url,
   };
 }
 
@@ -230,18 +183,6 @@ const DEMOS = [
   `Timothée Chalamet smart-casual date, soft tailoring + boots`,
   `Hailey Bieber off-duty street, under €300, neutrals + leather`,
 ];
-
-type Resolved = {
-  url: string;
-  affiliate_url?: string;
-  image?: string;
-  price?: number;
-  currency?: string;
-  retailer?: string;
-  availability?: string;
-  title?: string;
-  brand?: string;
-};
 
 export default function StylistPage() {
   const [prefs, setPrefs] = React.useState<Prefs>(() => {
@@ -275,45 +216,9 @@ export default function StylistPage() {
   const [messages, setMessages] = React.useState<Msg[]>([]);
   const [input, setInput] = React.useState("");
   const [sending, setSending] = React.useState(false);
-
-  // Resolver cache: productId -> resolved real product
-  const [resolved, setResolved] = React.useState<Record<string, Resolved>>({});
-
-  const resolveProduct = React.useCallback(async (p: UiProduct) => {
-    const key = p.id;
-    if (resolved[key]) return;
-
-    const q = `${p.brand ?? ""} ${p.title}`.trim();
-    if (!q) return;
-
-    try {
-      const res = await fetch("/api/products/search", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ query: q, limit: 1 }),
-      });
-      if (!res.ok) return;
-      const data = (await res.json()) as { ok?: boolean; items?: Array<Record<string, unknown>> };
-      const first = Array.isArray(data.items) ? data.items[0] : null;
-      if (!first || typeof first.url !== "string" || !first.url) return;
-
-      const next: Resolved = {
-        url: first.url as string,
-        affiliate_url: typeof first.affiliate_url === "string" ? (first.affiliate_url as string) : undefined,
-        image: typeof first.image === "string" ? (first.image as string) : undefined,
-        price: typeof first.price === "number" ? (first.price as number) : undefined,
-        currency: typeof first.currency === "string" ? (first.currency as string) : undefined,
-        retailer: typeof first.retailer === "string" ? (first.retailer as string) : undefined,
-        availability: typeof first.availability === "string" ? (first.availability as string) : undefined,
-        title: typeof first.title === "string" ? (first.title as string) : undefined,
-        brand: typeof first.brand === "string" ? (first.brand as string) : undefined,
-      };
-
-      setResolved((cur) => ({ ...cur, [key]: next }));
-    } catch {
-      // ignore
-    }
-  }, [resolved]);
+  const [look, setLook] = React.useState<LookResponse | null>(null);
+  const [jobId, setJobId] = React.useState<string | null>(null);
+  const [polling, setPolling] = React.useState(false);
 
   const send = React.useCallback(
     async (text: string) => {
@@ -326,43 +231,70 @@ export default function StylistPage() {
       setSending(true);
 
       try {
-        const res = await fetch("/api/chat", {
+        setLook(null);
+        setJobId(null);
+        setPolling(false);
+
+        const res = await fetch("/api/styleplan", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            messages: nextMsgs,
-            preferences: {
+            prompt: trimmed,
+            prefs: {
               gender: prefs.gender,
               bodyType: prefs.bodyType,
               budget: prefs.budget,
               country: prefs.country,
-              styleKeywords: (prefs.keywords || []).join(", "),
-              sizeTop: sizes.top,
-              sizeBottom: sizes.bottom,
-              sizeDress: sizes.dress,
-              sizeShoe: sizes.shoe,
+              keywords: prefs.keywords,
+              sizes: {
+                top: sizes.top,
+                bottom: sizes.bottom,
+                dress: sizes.dress,
+                shoe: sizes.shoe,
+              },
             },
           }),
         });
 
-        const replyText = await res.text();
-        setMessages((curr) => [...curr, { role: "assistant", content: replyText }]);
+        const data = (await res.json()) as { ok?: boolean; plan?: StylePlan };
+        if (!data.ok || !data.plan) {
+          setMessages((curr) => [
+            ...curr,
+            {
+              role: "assistant",
+              content:
+                "I hit a snag building the plan. Try tweaking the budget or adding a clearer occasion.",
+            },
+          ]);
+          return;
+        }
+
+        const plan = data.plan;
+        setMessages((curr) => [
+          ...curr,
+          { role: "assistant", content: buildPhaseOneMessage(trimmed, plan) },
+        ]);
+
+        const jobRes = await fetch("/api/look", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ plan }),
+        });
+
+        const jobData = (await jobRes.json()) as { ok?: boolean; job_id?: string };
+        if (jobData.ok && jobData.job_id) {
+          setJobId(jobData.job_id);
+          setPolling(true);
+        }
       } catch {
-        const fallback: AiJson = {
-          brief:
-            "I hit a connectivity issue. Here is a capsule-based fallback look while we recover.",
-          tips: [
-            "Keep to one or two base colors for high remix value.",
-            "Use one structured piece to sharpen the silhouette.",
-          ],
-          why: [
-            "These cuts flatter varied body types.",
-            "Each item can rotate across multiple outfits.",
-          ],
-          products: [],
-          total: { value: null, currency: "EUR" },
-        };
-        setMessages((curr) => [...curr, { role: "assistant", content: JSON.stringify(fallback) }]);
+        setMessages((curr) => [
+          ...curr,
+          {
+            role: "assistant",
+            content:
+              "I hit a connectivity issue. Try again in a moment and I’ll build the plan cleanly.",
+          },
+        ]);
       } finally {
         setSending(false);
       }
@@ -375,20 +307,33 @@ export default function StylistPage() {
     void send(input);
   };
 
-  // When a new assistant message arrives, trigger resolution for any weak products.
   React.useEffect(() => {
-    const last = messages[messages.length - 1];
-    if (!last || last.role !== "assistant") return;
-    const ai = coerceAiJson(last.content);
-    if (!ai) return;
+    if (!polling || !jobId) return;
+    let cancelled = false;
 
-    for (const p of ai.products) {
-      // resolve if missing url OR missing image OR missing price
-      if (!p.url || !p.image || p.price == null) {
-        void resolveProduct(p);
+    const poll = async () => {
+      try {
+        const res = await fetch(`/api/look/${jobId}`);
+        if (!res.ok) return;
+        const data = (await res.json()) as { ok?: boolean; status?: LookResponse["status"]; result?: LookResponse };
+        if (!data.ok || !data.result) return;
+        if (cancelled) return;
+        setLook(data.result);
+        if (data.status === "complete" || data.status === "failed" || data.status === "partial") {
+          setPolling(false);
+        }
+      } catch {
+        // ignore
       }
-    }
-  }, [messages, resolveProduct]);
+    };
+
+    const interval = setInterval(poll, 1200);
+    void poll();
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [polling, jobId]);
 
   return (
     <main className="mx-auto max-w-6xl px-4 py-6">
@@ -515,8 +460,6 @@ export default function StylistPage() {
 
         <div className="grid gap-3">
           {messages.map((m, i) => {
-            const ai = m.role === "assistant" ? coerceAiJson(m.content) : null;
-
             return (
               <div
                 key={i}
@@ -525,134 +468,134 @@ export default function StylistPage() {
                 <p className="mb-1 text-[10px] uppercase tracking-wide text-gray-500">
                   {m.role === "user" ? "You" : "RunwayTwin Stylist"}
                 </p>
-
-                {ai ? (
-                  <div className="grid gap-3">
-                    <p className="text-gray-900">{ai.brief}</p>
-
-                    <div className="inline-flex items-center gap-2 rounded-full border bg-gray-50 px-3 py-1 text-[10px] text-gray-700">
-                      <span>Est. total (if priced):</span>
-                      <span className="font-semibold">
-                        {ai.total.value != null ? `${ai.total.currency} ${ai.total.value}` : "—"}
-                      </span>
-                    </div>
-
-                    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-                      {ai.products.map((p) => {
-                        const r = resolved[p.id];
-                        const url = r?.affiliate_url ?? r?.url ?? p.affiliate_url ?? p.url;
-                        const img = proxyImage(r?.image ?? p.image);
-                        const title = r?.title ?? p.title;
-                        const brand = r?.brand ?? p.brand;
-                        const price = r?.price ?? p.price;
-                        const currency = r?.currency ?? p.currency;
-                        const retailer = r?.retailer ?? p.retailer;
-                        const availability = r?.availability ?? p.availability;
-
-                        const favPayload = {
-                          id: p.id,
-                          title,
-                          url: url ?? undefined,
-                          image: img ?? undefined,
-                          brand: brand ?? undefined,
-                          category: p.category,
-                          price: price ?? undefined,
-                          currency: currency ?? undefined,
-                          retailer: retailer ?? undefined,
-                        };
-
-                        const saved = fav.has(favPayload);
-
-                        return (
-                          <article key={p.id} className="group flex flex-col rounded-2xl border p-3">
-                            <div className="relative aspect-[4/5] w-full overflow-hidden rounded-xl bg-gray-100">
-                              {img ? (
-                                // eslint-disable-next-line @next/next/no-img-element
-                                <img
-                                  src={img}
-                                  alt={title}
-                                  className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-                                  loading="lazy"
-                                />
-                              ) : null}
-                              <button
-                                type="button"
-                                onClick={() => fav.toggle(favPayload)}
-                                className={`absolute right-2 top-2 rounded-full px-2 py-1 text-[9px] font-semibold shadow-sm ${
-                                  saved
-                                    ? "bg-black text-white"
-                                    : "bg-white/90 text-black border border-gray-200"
-                                }`}
-                              >
-                                {saved ? "Saved" : "Save"}
-                              </button>
-                            </div>
-
-                            <h3 className="mt-2 line-clamp-2 text-xs font-semibold text-gray-900">
-                              {title}
-                            </h3>
-                            <p className="text-[10px] text-gray-500">
-                              {brand ?? "—"} • {p.category}
-                            </p>
-
-                            <div className="mt-1 text-[10px] text-gray-800">
-                              {price != null ? `${currency} ${price}` : "Price at retailer"}
-                            </div>
-
-                            <div className="mt-2 flex gap-2">
-                              {url ? (
-                                <a
-                                  href={url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="inline-flex flex-1 items-center justify-center rounded-lg border px-2 py-1 text-[10px] font-medium hover:bg-gray-50"
-                                >
-                                  View
-                                </a>
-                              ) : (
-                                <span className="inline-flex flex-1 items-center justify-center rounded-lg border px-2 py-1 text-[9px] text-gray-500">
-                                  Resolving…
-                                </span>
-                              )}
-                            </div>
-                          </article>
-                        );
-                      })}
-                    </div>
-
-                    {(ai.why.length > 0 || ai.tips.length > 0) && (
-                      <div className="grid gap-2 pt-2">
-                        {ai.tips.length > 0 ? (
-                          <div>
-                            <p className="text-xs font-semibold">The Look</p>
-                            <ul className="list-disc pl-5 text-xs text-gray-700">
-                              {ai.tips.map((x) => (
-                                <li key={x}>{x}</li>
-                              ))}
-                            </ul>
-                          </div>
-                        ) : null}
-
-                        {ai.why.length > 0 ? (
-                          <div>
-                            <p className="text-xs font-semibold">Why this works</p>
-                            <ul className="list-disc pl-5 text-xs text-gray-700">
-                              {ai.why.map((x) => (
-                                <li key={x}>{x}</li>
-                              ))}
-                            </ul>
-                          </div>
-                        ) : null}
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  <p className="whitespace-pre-wrap text-gray-800">{m.content}</p>
-                )}
+                <p className="whitespace-pre-wrap text-gray-800">{m.content}</p>
               </div>
             );
           })}
         </div>
+
+        {(look || polling) && (
+          <div className="grid gap-3 rounded-2xl border bg-white p-3 text-sm">
+            <p className="mb-1 text-[10px] uppercase tracking-wide text-gray-500">
+              RunwayTwin Stylist
+            </p>
+            <p className="whitespace-pre-wrap text-gray-900">
+              {look?.message || "Pulling pieces that fit the plan — stay with me."}
+            </p>
+
+            <div className="inline-flex items-center gap-2 rounded-full border bg-gray-50 px-3 py-1 text-[10px] text-gray-700">
+              <span>Est. total (if priced):</span>
+              <span className="font-semibold">
+                {look?.total_price != null ? `${look.currency} ${look.total_price}` : "—"}
+              </span>
+            </div>
+
+            {look?.missing_slots?.length ? (
+              <p className="text-[11px] text-gray-600">
+                Still searching for: {look.missing_slots.join(", ")}. Want me to loosen budget or colors?
+              </p>
+            ) : null}
+
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+              {(() => {
+                const products = look?.slots?.length ? look.slots.map(toUiProduct) : [];
+                const cards = products.length
+                  ? products.map((p) => ({ type: "product" as const, p }))
+                  : Array.from({ length: 4 }).map((_, idx) => ({
+                      type: "skeleton" as const,
+                      id: `skeleton-${idx}`,
+                    }));
+
+                return cards.map((card) => {
+                  if (card.type === "skeleton") {
+                    return (
+                      <div
+                        key={card.id}
+                        className="flex flex-col gap-2 rounded-2xl border p-3"
+                      >
+                        <div className="aspect-[4/5] w-full rounded-xl bg-gray-100 animate-pulse" />
+                        <div className="h-3 rounded bg-gray-100 animate-pulse" />
+                        <div className="h-3 w-2/3 rounded bg-gray-100 animate-pulse" />
+                      </div>
+                    );
+                  }
+
+                  const p = card.p;
+                  const img = proxyImage(p.image);
+                  const url = p.affiliate_url ?? p.url;
+                  const favPayload = {
+                    id: p.id,
+                    title: p.title,
+                    url: url ?? undefined,
+                    image: img ?? undefined,
+                    brand: p.brand ?? undefined,
+                    category: p.category,
+                    price: p.price ?? undefined,
+                    currency: p.currency ?? undefined,
+                    retailer: p.retailer ?? undefined,
+                  };
+
+                  const saved = fav.has(favPayload);
+
+                  return (
+                    <article key={p.id} className="group flex flex-col rounded-2xl border p-3">
+                      <div className="relative aspect-[4/5] w-full overflow-hidden rounded-xl bg-gray-100">
+                        {img ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={img}
+                            alt={p.title}
+                            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                            loading="lazy"
+                          />
+                        ) : null}
+                        <button
+                          type="button"
+                          onClick={() => fav.toggle(favPayload)}
+                          className={`absolute right-2 top-2 rounded-full px-2 py-1 text-[9px] font-semibold shadow-sm ${
+                            saved
+                              ? "bg-black text-white"
+                              : "bg-white/90 text-black border border-gray-200"
+                          }`}
+                        >
+                          {saved ? "Saved" : "Save"}
+                        </button>
+                      </div>
+
+                      <h3 className="mt-2 line-clamp-2 text-xs font-semibold text-gray-900">
+                        {p.title}
+                      </h3>
+                      <p className="text-[10px] text-gray-500">
+                        {p.brand ?? "—"} • {p.category}
+                      </p>
+
+                      <div className="mt-1 text-[10px] text-gray-800">
+                        {p.price != null ? `${p.currency} ${p.price}` : "Price at retailer"}
+                      </div>
+
+                      <div className="mt-2 flex gap-2">
+                        {url ? (
+                          <a
+                            href={url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex flex-1 items-center justify-center rounded-lg border px-2 py-1 text-[10px] font-medium hover:bg-gray-50"
+                          >
+                            View
+                          </a>
+                        ) : (
+                          <span className="inline-flex flex-1 items-center justify-center rounded-lg border px-2 py-1 text-[9px] text-gray-500">
+                            Resolving…
+                          </span>
+                        )}
+                      </div>
+                    </article>
+                  );
+                });
+              })()}
+            </div>
+          </div>
+        )}
 
         <form onSubmit={onSubmit} className="mt-2 flex gap-2">
           <input

--- a/app/stylist/page.tsx
+++ b/app/stylist/page.tsx
@@ -622,22 +622,22 @@ export default function StylistPage() {
 
                     {(ai.why.length > 0 || ai.tips.length > 0) && (
                       <div className="grid gap-2 pt-2">
-                        {ai.why.length > 0 ? (
+                        {ai.tips.length > 0 ? (
                           <div>
-                            <p className="text-xs font-semibold">Why this fits you</p>
+                            <p className="text-xs font-semibold">The Look</p>
                             <ul className="list-disc pl-5 text-xs text-gray-700">
-                              {ai.why.map((x) => (
+                              {ai.tips.map((x) => (
                                 <li key={x}>{x}</li>
                               ))}
                             </ul>
                           </div>
                         ) : null}
 
-                        {ai.tips.length > 0 ? (
+                        {ai.why.length > 0 ? (
                           <div>
-                            <p className="text-xs font-semibold">Styling tips</p>
+                            <p className="text-xs font-semibold">Why this works</p>
                             <ul className="list-disc pl-5 text-xs text-gray-700">
-                              {ai.tips.map((x) => (
+                              {ai.why.map((x) => (
                                 <li key={x}>{x}</li>
                               ))}
                             </ul>

--- a/app/stylist/page.tsx
+++ b/app/stylist/page.tsx
@@ -33,6 +33,9 @@ type UiProduct = {
   title: string;
   url: string | null;
   brand: string | null;
+  affiliate_url: string | null;
+  retailer: string | null;
+  availability: string | null;
   category: UiCategory;
   price: number | null;
   currency: string;
@@ -139,11 +142,29 @@ function asProduct(x: unknown, fallbackCurrency: string): UiProduct | null {
       ? (x["image"] as string)
       : null;
 
+  const affiliateUrl =
+    typeof x["affiliate_url"] === "string" && x["affiliate_url"].trim().length
+      ? (x["affiliate_url"] as string)
+      : url;
+
+  const retailer =
+    typeof x["retailer"] === "string" && x["retailer"].trim().length
+      ? (x["retailer"] as string)
+      : null;
+
+  const availability =
+    typeof x["availability"] === "string" && x["availability"].trim().length
+      ? (x["availability"] as string)
+      : null;
+
   return {
     id: id || (url ?? title),
     title,
     url,
     brand,
+    affiliate_url: affiliateUrl,
+    retailer,
+    availability,
     category: cat,
     price,
     currency,
@@ -212,10 +233,12 @@ const DEMOS = [
 
 type Resolved = {
   url: string;
+  affiliate_url?: string;
   image?: string;
   price?: number;
   currency?: string;
   retailer?: string;
+  availability?: string;
   title?: string;
   brand?: string;
 };
@@ -276,10 +299,12 @@ export default function StylistPage() {
 
       const next: Resolved = {
         url: first.url as string,
+        affiliate_url: typeof first.affiliate_url === "string" ? (first.affiliate_url as string) : undefined,
         image: typeof first.image === "string" ? (first.image as string) : undefined,
         price: typeof first.price === "number" ? (first.price as number) : undefined,
         currency: typeof first.currency === "string" ? (first.currency as string) : undefined,
         retailer: typeof first.retailer === "string" ? (first.retailer as string) : undefined,
+        availability: typeof first.availability === "string" ? (first.availability as string) : undefined,
         title: typeof first.title === "string" ? (first.title as string) : undefined,
         brand: typeof first.brand === "string" ? (first.brand as string) : undefined,
       };
@@ -515,12 +540,14 @@ export default function StylistPage() {
                     <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
                       {ai.products.map((p) => {
                         const r = resolved[p.id];
-                        const url = r?.url ?? p.url;
+                        const url = r?.affiliate_url ?? r?.url ?? p.affiliate_url ?? p.url;
                         const img = proxyImage(r?.image ?? p.image);
                         const title = r?.title ?? p.title;
                         const brand = r?.brand ?? p.brand;
                         const price = r?.price ?? p.price;
                         const currency = r?.currency ?? p.currency;
+                        const retailer = r?.retailer ?? p.retailer;
+                        const availability = r?.availability ?? p.availability;
 
                         const favPayload = {
                           id: p.id,
@@ -531,6 +558,7 @@ export default function StylistPage() {
                           category: p.category,
                           price: price ?? undefined,
                           currency: currency ?? undefined,
+                          retailer: retailer ?? undefined,
                         };
 
                         const saved = fav.has(favPayload);
@@ -646,4 +674,3 @@ export default function StylistPage() {
     </main>
   );
 }
-

--- a/components/InlineProductCard.tsx
+++ b/components/InlineProductCard.tsx
@@ -18,34 +18,43 @@ export default function InlineProductCard({ item }: Props) {
   const retailer =
     item.retailer ??
     (safeHost(item.url) ? safeHost(item.url) : "store");
+  const link = item.affiliate_url ?? item.url;
 
   return (
     <article className="group flex h-full flex-col overflow-hidden rounded-2xl border bg-white transition hover:shadow-md focus-within:shadow-md">
-      <a
-        href={item.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="relative block aspect-[4/5] overflow-hidden"
-        aria-label={`${item.title} — open product`}
-      >
-        {/* Image */}
-        {item.image ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={item.image}
-            alt={item.title}
-            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-            loading="lazy"
-          />
-        ) : (
-          <div aria-hidden className="h-full w-full bg-gray-100" />
-        )}
+      {link ? (
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="relative block aspect-[4/5] overflow-hidden"
+          aria-label={`${item.title} — open product`}
+        >
+          {/* Image */}
+          {item.image ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={item.image}
+              alt={item.title}
+              className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+              loading="lazy"
+            />
+          ) : (
+            <div aria-hidden className="h-full w-full bg-gray-100" />
+          )}
 
-        {/* Retailer badge */}
-        <div className="pointer-events-none absolute left-2 top-2 rounded-full bg-black/70 px-2 py-1 text-[11px] font-medium text-white">
-          {retailer}
+          {/* Retailer badge */}
+          <div className="pointer-events-none absolute left-2 top-2 rounded-full bg-black/70 px-2 py-1 text-[11px] font-medium text-white">
+            {retailer}
+          </div>
+        </a>
+      ) : (
+        <div className="relative block aspect-[4/5] overflow-hidden bg-gray-100">
+          <div className="pointer-events-none absolute left-2 top-2 rounded-full bg-black/70 px-2 py-1 text-[11px] font-medium text-white">
+            {retailer}
+          </div>
         </div>
-      </a>
+      )}
 
       <div className="grid gap-2 p-3">
         <h3 className="line-clamp-2 text-sm font-medium leading-snug">{item.title}</h3>
@@ -54,14 +63,20 @@ export default function InlineProductCard({ item }: Props) {
           <span className="font-semibold text-gray-900">{price}</span>
         </div>
         <div className="mt-1 grid grid-cols-2 gap-2">
-          <a
-            href={item.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center justify-center rounded-xl border border-gray-300 px-3 py-2 text-sm font-medium hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-black/60"
-          >
-            View
-          </a>
+          {link ? (
+            <a
+              href={link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center rounded-xl border border-gray-300 px-3 py-2 text-sm font-medium hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-black/60"
+            >
+              View
+            </a>
+          ) : (
+            <span className="inline-flex items-center justify-center rounded-xl border border-gray-300 px-3 py-2 text-sm font-medium text-gray-400">
+              Unavailable
+            </span>
+          )}
           <FavButton product={item} />
         </div>
       </div>

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -19,6 +19,7 @@ function uniqueKey(p: Product) {
 }
 
 export function ProductCard({ item }: { item: Product }) {
+  const link = item.affiliate_url ?? item.url;
   const key = uniqueKey(item);
 
   const [imgSrc, setImgSrc] = React.useState<string>(item.image || "/placeholder.svg");
@@ -49,15 +50,15 @@ export function ProductCard({ item }: { item: Product }) {
       <div className="mt-3 grid gap-1">
         <h3 className="line-clamp-2 text-sm font-semibold">{item.title}</h3>
         <p className="text-xs text-gray-500">
-          {(item.brand || item.retailer || "—") + " · " + (item.fit?.category || "Accessory")}
+          {(item.brand || item.retailer || "—") + " · " + (item.fit?.category || item.category || "Accessory")}
         </p>
         <p className="text-xs text-gray-700">{formatPrice(item.price, item.currency)}</p>
       </div>
 
       <div className="mt-3">
-        {item.url ? (
+        {link ? (
           <a
-            href={item.url}
+            href={link}
             target="_blank"
             rel="noreferrer"
             className="inline-flex w-full items-center justify-center rounded-xl border px-3 py-2 text-sm font-medium hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-black/60"

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -4,7 +4,7 @@
 import * as React from "react";
 import type { Product } from "@/lib/affiliates/types";
 
-function formatPrice(price?: number, currency?: string) {
+function formatPrice(price?: number | null, currency?: string | null) {
   if (typeof price !== "number") return "Price at retailer";
   const cur = currency || "EUR";
   try {
@@ -92,4 +92,3 @@ export function ProductCardSkeleton() {
     </div>
   );
 }
-

--- a/lib/affiliates/providers/amazon.ts
+++ b/lib/affiliates/providers/amazon.ts
@@ -1,60 +1,16 @@
 // FILE: lib/affiliates/providers/amazon.ts
-import type { Provider, ProviderResult, Product, Category } from "../types";
-import { searchCatalog } from "@/lib/catalog/mock";
+import type { Provider, ProviderResult } from "../types";
 
 const MOCK = (process.env.MOCK_AFFILIATES || "true").toLowerCase() !== "false";
 
-function mapCategory(cat: string): Category {
-  switch (cat) {
-    case "top":
-      return "Top";
-    case "bottom":
-      return "Bottom";
-    case "outerwear":
-      return "Outerwear";
-    case "dress":
-      return "Dress";
-    case "shoes":
-      return "Shoes";
-    case "bag":
-      return "Bag";
-    default:
-      return "Accessory";
-  }
-}
-
-function mock(q: string, limit = 6): ProviderResult {
-  const items = searchCatalog({
-    q,
-    gender: "unisex",
-    budgetMax: 500,
-    keywords: q.split(/\s+/).filter(Boolean).slice(0, 6),
-  }).slice(0, limit);
-
-  const base: Product[] = items.map((item) => ({
-    id: item.id,
-    title: item.title,
-    brand: item.brand,
-    retailer: item.retailer,
-    url: item.url,
-    image: item.image,
-    price: item.price,
-    currency: item.currency,
-    availability: "in_stock",
-    fit: {
-      category: mapCategory(item.categories[0] || "accessory"),
-      gender: item.gender,
-    },
-    source: "amazon",
-  }));
-  return { provider: "amazon", items: base };
+function mock(): ProviderResult {
+  return { provider: "amazon", items: [] };
 }
 
 export const amazonProvider: Provider = {
   async search(q: string, opts?: { limit?: number }) {
     // TODO: real PA-API integration (Node runtime required). For now, mock.
-    const limit = opts?.limit ?? 6;
-    if (MOCK) return mock(q, limit);
-    return mock(q, limit); // fallback until real integration
+    if (MOCK) return mock();
+    return mock(); // fallback until real integration
   },
 };

--- a/lib/affiliates/providers/amazon.ts
+++ b/lib/affiliates/providers/amazon.ts
@@ -4,6 +4,7 @@ import type { Provider, ProviderResult, Product } from "../types";
 const MOCK = (process.env.MOCK_AFFILIATES || "true").toLowerCase() !== "false";
 
 function mock(q: string, limit = 6): ProviderResult {
+  const categories = ["Top", "Bottom", "Dress", "Outerwear", "Shoes"] as const;
   const base: Product[] = Array.from({ length: limit }).map((_, i) => ({
     id: `amz-${i}`,
     title: `${q} — Amazon pick #${i + 1}`,
@@ -15,7 +16,7 @@ function mock(q: string, limit = 6): ProviderResult {
     currency: "EUR",
     availability: "in_stock",
     fit: {
-      category: ["top", "bottom", "dress", "outerwear", "shoes"][i % 5],
+      category: categories[i % categories.length],
       gender: "female",
     },
   }));

--- a/lib/affiliates/providers/amazon.ts
+++ b/lib/affiliates/providers/amazon.ts
@@ -1,16 +1,58 @@
 // FILE: lib/affiliates/providers/amazon.ts
-import type { Provider, ProviderResult } from "../types";
+import type { Provider, ProviderResult, Product, Category } from "../types";
+import { searchCatalog } from "@/lib/catalog/mock";
 
 const MOCK = (process.env.MOCK_AFFILIATES || "true").toLowerCase() !== "false";
 
-function mock(): ProviderResult {
-  return { provider: "amazon", items: [] };
+function mapCategory(cat: string): Category {
+  switch (cat) {
+    case "top":
+      return "Top";
+    case "bottom":
+      return "Bottom";
+    case "outerwear":
+      return "Outerwear";
+    case "dress":
+      return "Dress";
+    case "shoes":
+      return "Shoes";
+    case "bag":
+      return "Bag";
+    default:
+      return "Accessory";
+  }
+}
+
+function mock(q: string, limit = 6): ProviderResult {
+  const items = searchCatalog({
+    q,
+    gender: "unisex",
+    budgetMax: 500,
+    keywords: q.split(/\s+/).filter(Boolean).slice(0, 6),
+  }).slice(0, limit);
+
+  const base: Product[] = items.map((item) => ({
+    id: item.id,
+    title: item.title,
+    brand: item.brand,
+    retailer: item.retailer,
+    url: item.url,
+    affiliate_url: item.url,
+    image: item.image,
+    price: item.price,
+    currency: item.currency,
+    availability: item.availability,
+    category: mapCategory(item.categories[0] || "accessory"),
+    source: "amazon",
+  }));
+  return { provider: "amazon", items: base };
 }
 
 export const amazonProvider: Provider = {
   async search(q: string, opts?: { limit?: number }) {
     // TODO: real PA-API integration (Node runtime required). For now, mock.
-    if (MOCK) return mock();
-    return mock(); // fallback until real integration
+    const limit = opts?.limit ?? 6;
+    if (MOCK) return mock(q, limit);
+    return mock(q, limit); // fallback until real integration
   },
 };

--- a/lib/affiliates/providers/awin.ts
+++ b/lib/affiliates/providers/awin.ts
@@ -1,5 +1,5 @@
 // FILE: lib/affiliates/providers/awin.ts
-import type { Provider, ProviderResult, Product, Currency } from "@/lib/affiliates/types";
+import type { Provider, ProviderResult, Product, Currency, Category } from "@/lib/affiliates/types";
 
 /**
  * AWIN Product Search provider
@@ -83,8 +83,26 @@ function pickImage(p: AwinApiProduct): string | undefined {
   return str(p.largeImage) || str(p.imageUrl);
 }
 
-function pickCategory(p: AwinApiProduct): string | undefined {
-  return str(p.categoryName) || str(p.primaryCategory);
+function pickCategory(p: AwinApiProduct): Category | undefined {
+  const raw = (str(p.categoryName) || str(p.primaryCategory) || "").toLowerCase();
+  if (!raw) return undefined;
+  if (raw.includes("shoe") || raw.includes("sneaker") || raw.includes("boot") || raw.includes("heel"))
+    return "Shoes";
+  if (raw.includes("dress")) return "Dress";
+  if (raw.includes("trouser") || raw.includes("pants") || raw.includes("jean") || raw.includes("skirt"))
+    return "Bottom";
+  if (raw.includes("coat") || raw.includes("jacket") || raw.includes("trench") || raw.includes("blazer"))
+    return "Outerwear";
+  if (raw.includes("bag") || raw.includes("handbag")) return "Bag";
+  if (
+    raw.includes("shirt") ||
+    raw.includes("tee") ||
+    raw.includes("top") ||
+    raw.includes("blouse") ||
+    raw.includes("knit")
+  )
+    return "Top";
+  return "Accessory";
 }
 
 function mapOne(raw: AwinApiProduct): Product | null {
@@ -209,4 +227,3 @@ export const awinProvider: Provider = {
     return { provider: "awin", items };
   },
 };
-

--- a/lib/affiliates/providers/rakuten.ts
+++ b/lib/affiliates/providers/rakuten.ts
@@ -1,12 +1,52 @@
 // FILE: lib/affiliates/providers/rakuten.ts
 // Mock-safe Rakuten provider (plug real API later).
 
-import type { Provider, ProviderResult, Currency } from "@/lib/affiliates/types";
+import type { Provider, ProviderResult, Currency, Product, Category } from "@/lib/affiliates/types";
+import { searchCatalog } from "@/lib/catalog/mock";
+
+function mapCategory(cat: string): Category {
+  switch (cat) {
+    case "top":
+      return "Top";
+    case "bottom":
+      return "Bottom";
+    case "outerwear":
+      return "Outerwear";
+    case "dress":
+      return "Dress";
+    case "shoes":
+      return "Shoes";
+    case "bag":
+      return "Bag";
+    default:
+      return "Accessory";
+  }
+}
 
 export const rakutenProvider: Provider = {
   async search(q: string, opts?: { limit?: number; currency?: Currency }): Promise<ProviderResult> {
-    void q;
-    void opts;
-    return { provider: "rakuten", items: [] };
+    const limit = Math.min(Math.max(opts?.limit ?? 6, 1), 20);
+    const items = searchCatalog({
+      q,
+      gender: "unisex",
+      budgetMax: 500,
+      keywords: q.split(/\s+/).filter(Boolean).slice(0, 6),
+    }).slice(0, limit);
+
+    const mapped: Product[] = items.map((item) => ({
+      id: `${item.id}-rkt`,
+      title: item.title,
+      brand: item.brand,
+      retailer: item.retailer,
+      url: item.url,
+      affiliate_url: item.url,
+      image: item.image,
+      price: item.price,
+      currency: item.currency,
+      availability: item.availability,
+      category: mapCategory(item.categories[0] || "accessory"),
+      source: "rakuten",
+    }));
+    return { provider: "rakuten", items: mapped };
   },
 };

--- a/lib/affiliates/providers/rakuten.ts
+++ b/lib/affiliates/providers/rakuten.ts
@@ -1,39 +1,12 @@
 // FILE: lib/affiliates/providers/rakuten.ts
 // Mock-safe Rakuten provider (plug real API later).
 
-import type { Provider, ProviderResult, Product, Currency } from "@/lib/affiliates/types";
-
-const MOCK: Product[] = [
-  {
-    id: "rkt-knit",
-    title: "Merino Crew Knit",
-    brand: "UNIQLO",
-    retailer: "rakuten",
-    url: "https://www.uniqlo.com/",
-    image: "",
-    price: 39,
-    currency: "EUR",
-    fit: { category: "Top", gender: "unisex" },
-  },
-  {
-    id: "rkt-trouser",
-    title: "Wide Wool Trousers",
-    brand: "ARKET",
-    retailer: "rakuten",
-    url: "https://www.arket.com/",
-    image: "",
-    price: 129,
-    currency: "EUR",
-    fit: { category: "Bottom", gender: "unisex" },
-  },
-];
+import type { Provider, ProviderResult, Currency } from "@/lib/affiliates/types";
 
 export const rakutenProvider: Provider = {
   async search(q: string, opts?: { limit?: number; currency?: Currency }): Promise<ProviderResult> {
-    const limit = Math.min(Math.max(opts?.limit ?? 6, 1), 20);
-    const currency = (opts?.currency || "EUR") as Currency;
-    const out = MOCK.slice(0, limit).map((p, idx) => ({ ...p, id: `${p.id}-${idx}`, currency }));
-    return { provider: "rakuten", items: out };
+    void q;
+    void opts;
+    return { provider: "rakuten", items: [] };
   },
 };
-

--- a/lib/affiliates/providers/web.ts
+++ b/lib/affiliates/providers/web.ts
@@ -1,7 +1,7 @@
 // FILE: lib/affiliates/providers/web.ts
 import type { Product, ProviderResult } from "@/lib/affiliates/types";
 
-type SearchOpts = { limit: number };
+type SearchOpts = { limit: number; country?: string };
 
 // Put category under fit.category (since Product has `fit?: { category?: ... }`)
 type FitCategory = NonNullable<Product["fit"]>["category"];

--- a/lib/affiliates/types.ts
+++ b/lib/affiliates/types.ts
@@ -29,8 +29,10 @@ export type Product = {
   price?: number | null;
   currency?: Currency | null;
   brand?: string | null;
+  affiliate_url?: string | null;
   retailer?: string | null;
   availability?: Availability | null;
+  category?: Category;
 
   // Structured metadata (kept optional to avoid breaking older providers)
   fit?: {

--- a/lib/affiliates/types.ts
+++ b/lib/affiliates/types.ts
@@ -12,36 +12,56 @@ export type Category =
   | "Bag"
   | "Accessory";
 
+export type Currency = string;
+
+export type Availability =
+  | "in_stock"
+  | "out_of_stock"
+  | "preorder"
+  | "unknown"
+  | (string & {});
+
 export type Product = {
   id: string;
   title: string;
   url: string;
-  image: string | null;
-  price: number | null;
-  currency: string | null;
-  brand: string | null;
+  image?: string | null;
+  price?: number | null;
+  currency?: Currency | null;
+  brand?: string | null;
+  retailer?: string | null;
+  availability?: Availability | null;
 
   // Structured metadata (kept optional to avoid breaking older providers)
   fit?: {
     category?: Category;
     reason?: string;
     tags?: string[];
+    gender?: "female" | "male" | "unisex";
+    sizes?: Array<string | number>;
   };
 
+  attrs?: Record<string, unknown>;
+
   // Provenance
-  source: ProviderKey;
+  source?: ProviderKey;
 };
 
 export type ProviderSearchOptions = {
-  limit: number;
+  limit?: number;
   country?: string; // e.g. "NL"
+  currency?: Currency;
+  [key: string]: unknown;
 };
 
 export type ProviderSearchResult = {
+  provider?: ProviderKey;
   items: Product[];
 };
 
+export type ProviderResult = ProviderSearchResult;
+
 export type Provider = {
-  key: ProviderKey;
-  search: (query: string, opts: ProviderSearchOptions) => Promise<ProviderSearchResult>;
+  key?: ProviderKey;
+  search: (query: string, opts?: ProviderSearchOptions) => Promise<ProviderSearchResult>;
 };

--- a/lib/affiliates/validate.ts
+++ b/lib/affiliates/validate.ts
@@ -1,0 +1,99 @@
+// FILE: lib/affiliates/validate.ts
+import type { Category, Product } from "@/lib/affiliates/types";
+
+export type StrictProduct = {
+  id: string;
+  brand: string;
+  title: string;
+  price: number;
+  currency: string;
+  image: string;
+  affiliate_url: string;
+  retailer: string;
+  availability: string;
+  category: Category;
+  url: string;
+};
+
+function isNonEmptyString(x: unknown): x is string {
+  return typeof x === "string" && x.trim().length > 0;
+}
+
+function validUrl(x: unknown): string | null {
+  if (!isNonEmptyString(x)) return null;
+  try {
+    const u = new URL(x);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    if (u.pathname === "/" || u.pathname.trim() === "") return null;
+    return u.toString();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeCurrency(x: unknown): string | null {
+  if (!isNonEmptyString(x)) return null;
+  const cur = x.trim().toUpperCase();
+  if (!/^[A-Z]{3}$/.test(cur)) return null;
+  return cur;
+}
+
+function normalizeRetailer(x: unknown, url: string): string | null {
+  if (isNonEmptyString(x)) {
+    const v = x.trim();
+    if (v.includes(":") && !v.includes(".")) return v; // allow provider-tagged retailers like awin:123
+    if (v.includes(".")) return v.replace(/^www\./, "").toLowerCase();
+    return v.toLowerCase();
+  }
+  try {
+    return new URL(url).hostname.replace(/^www\./, "").toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function retailerMatchesUrl(retailer: string, url: string): boolean {
+  if (!retailer.includes(".")) return true;
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, "").toLowerCase();
+    const r = retailer.replace(/^www\./, "").toLowerCase();
+    return host === r || host.endsWith(`.${r}`);
+  } catch {
+    return false;
+  }
+}
+
+export function toStrictProduct(p: Product): StrictProduct | null {
+  const id = isNonEmptyString(p.id) ? p.id : null;
+  const title = isNonEmptyString(p.title) ? p.title.trim() : null;
+  const brand = isNonEmptyString(p.brand) ? p.brand.trim() : null;
+  const price =
+    typeof p.price === "number" && Number.isFinite(p.price) && p.price > 0 ? p.price : null;
+  const currency = normalizeCurrency(p.currency);
+  const url = validUrl(p.url);
+  const affiliate = validUrl(p.affiliate_url ?? p.url);
+  const image = validUrl(p.image);
+  const availability = isNonEmptyString(p.availability) ? p.availability.trim() : null;
+  const category = p.fit?.category ?? p.category ?? null;
+
+  if (!id || !title || !brand || !price || !currency || !url || !affiliate || !image) return null;
+  if (!availability || !category) return null;
+
+  const retailer = normalizeRetailer(p.retailer, url);
+  if (!retailer) return null;
+  if (!retailerMatchesUrl(retailer, affiliate)) return null;
+
+  return {
+    id,
+    title,
+    brand,
+    price,
+    currency,
+    image,
+    affiliate_url: affiliate,
+    retailer,
+    availability,
+    category,
+    url,
+  };
+}

--- a/lib/catalog/mock.ts
+++ b/lib/catalog/mock.ts
@@ -23,6 +23,7 @@ export type MockItem = {
   retailer: string;
   url: string;
   image: string;
+  availability: "in_stock" | "out_of_stock" | "unknown";
   tags: string[]; // style keywords
 };
 
@@ -41,8 +42,9 @@ export const CATALOG: MockItem[] = [
     price: 119,
     currency: "EUR",
     retailer: "zara.com",
-    url: "https://www.zara.com/",
+    url: "https://www.zara.com/nl/en/water-resistant-trench-coat-p123456.html",
     image: U(800, 1000, "trench"),
+    availability: "in_stock",
     tags: ["minimal", "tailoring", "rain", "neutral"],
   },
   {
@@ -54,8 +56,9 @@ export const CATALOG: MockItem[] = [
     price: 89,
     currency: "EUR",
     retailer: "cos.com",
-    url: "https://www.cos.com/",
+    url: "https://www.cos.com/en_eur/men/knitwear/product.merino-knit-sweater.123456.html",
     image: U(800, 1000, "knit"),
+    availability: "in_stock",
     tags: ["capsule", "minimal", "layering"],
   },
   {
@@ -67,8 +70,9 @@ export const CATALOG: MockItem[] = [
     price: 129,
     currency: "EUR",
     retailer: "arket.com",
-    url: "https://www.arket.com/",
+    url: "https://www.arket.com/en_eur/women/trousers/product.high-waist-tailored-trouser.123456.html",
     image: U(800, 1000, "trouser"),
+    availability: "in_stock",
     tags: ["tailoring", "work", "black"],
   },
   {
@@ -80,8 +84,9 @@ export const CATALOG: MockItem[] = [
     price: 165,
     currency: "EUR",
     retailer: "stories.com",
-    url: "https://www.stories.com/",
+    url: "https://www.stories.com/en_eur/shoes/boots/product.leather-ankle-boot.123456.html",
     image: U(800, 1000, "boots"),
+    availability: "in_stock",
     tags: ["minimal", "weather", "heel-low"],
   },
   {
@@ -93,8 +98,9 @@ export const CATALOG: MockItem[] = [
     price: 49,
     currency: "EUR",
     retailer: "mango.com",
-    url: "https://shop.mango.com/",
+    url: "https://shop.mango.com/nl/women/bags/product.structured-shoulder-bag_12345678.html",
     image: U(800, 1000, "bag"),
+    availability: "in_stock",
     tags: ["event", "minimal", "black"],
   },
   {
@@ -106,8 +112,9 @@ export const CATALOG: MockItem[] = [
     price: 690,
     currency: "EUR",
     retailer: "net-a-porter.com",
-    url: "https://www.net-a-porter.com/",
+    url: "https://www.net-a-porter.com/en-nl/shop/product/gianvito-rossi/shoes/123456.html",
     image: U(800, 1000, "sandal"),
+    availability: "in_stock",
     tags: ["evening", "glam"],
   },
   // ——— Mens / unisex ———
@@ -120,8 +127,9 @@ export const CATALOG: MockItem[] = [
     price: 19,
     currency: "EUR",
     retailer: "uniqlo.com",
-    url: "https://www.uniqlo.com/",
+    url: "https://www.uniqlo.com/eu/en/product/u-crew-neck-t-shirt-123456.html",
     image: U(800, 1000, "tee"),
+    availability: "in_stock",
     tags: ["minimal", "capsule"],
   },
   {
@@ -133,8 +141,9 @@ export const CATALOG: MockItem[] = [
     price: 110,
     currency: "EUR",
     retailer: "levi.com",
-    url: "https://www.levi.com/",
+    url: "https://www.levi.com/DE/en_DE/clothing/men/jeans/501-original-fit-jeans/p/123456",
     image: U(800, 1000, "jeans"),
+    availability: "in_stock",
     tags: ["denim", "casual"],
   },
   {
@@ -146,8 +155,9 @@ export const CATALOG: MockItem[] = [
     price: 225,
     currency: "EUR",
     retailer: "cos.com",
-    url: "https://www.cos.com/",
+    url: "https://www.cos.com/en_eur/men/tailoring/product.sharp-wool-blazer.123456.html",
     image: U(800, 1000, "blazer"),
+    availability: "in_stock",
     tags: ["tailoring", "work", "smart-casual"],
   },
   {
@@ -159,8 +169,9 @@ export const CATALOG: MockItem[] = [
     price: 99,
     currency: "EUR",
     retailer: "nike.com",
-    url: "https://www.nike.com/",
+    url: "https://www.nike.com/nl/t/court-sneakers-123456",
     image: U(800, 1000, "sneaker"),
+    availability: "in_stock",
     tags: ["street", "casual", "white"],
   },
 ];
@@ -206,4 +217,3 @@ export function searchCatalog(opts: {
   // Always return at least a basic set in deterministic order
   return scored.length ? scored : CATALOG.slice(0, 6);
 }
-

--- a/lib/hooks/useFavorites.ts
+++ b/lib/hooks/useFavorites.ts
@@ -2,7 +2,7 @@
 "use client";
 
 import * as React from "react";
-import type { Product } from "@/lib/affiliates/types";
+import type { Product, Category } from "@/lib/affiliates/types";
 
 /** ----------------------------------------------------------------
  * Backwards-compatible favorites store.
@@ -47,6 +47,23 @@ function isProduct(x: unknown): x is Product {
   );
 }
 
+function normalizeCategory(value: unknown): Category | undefined {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  const raw = value.toLowerCase();
+  if (raw.includes("shoe") || raw.includes("sneaker") || raw.includes("boot") || raw.includes("heel"))
+    return "Shoes";
+  if (raw.includes("dress")) return "Dress";
+  if (raw.includes("trouser") || raw.includes("pants") || raw.includes("jean") || raw.includes("skirt"))
+    return "Bottom";
+  if (raw.includes("coat") || raw.includes("jacket") || raw.includes("trench") || raw.includes("blazer"))
+    return "Outerwear";
+  if (raw.includes("bag") || raw.includes("handbag")) return "Bag";
+  if (raw.includes("shirt") || raw.includes("tee") || raw.includes("top") || raw.includes("blouse") || raw.includes("knit"))
+    return "Top";
+  if (raw.includes("accessory")) return "Accessory";
+  return undefined;
+}
+
 /** Normalize either a Product or legacy shape into a Product */
 function normalize(p: Product | LegacyFavProduct): Product | null {
   if (!p || typeof p !== "object") return null;
@@ -89,7 +106,7 @@ function normalize(p: Product | LegacyFavProduct): Product | null {
         ? lp.price
         : undefined,
     currency: typeof lp.currency === "string" ? lp.currency || undefined : undefined,
-    fit: lp.category ? { category: lp.category || undefined } : undefined,
+    fit: normalizeCategory(lp.category) ? { category: normalizeCategory(lp.category) } : undefined,
     attrs: undefined,
   };
   return prod;
@@ -189,4 +206,3 @@ export function useFavorites() {
 
   return { list, add, remove, toggle, has, clear };
 }
-

--- a/lib/hooks/useFavorites.ts
+++ b/lib/hooks/useFavorites.ts
@@ -75,6 +75,8 @@ function normalize(p: Product | LegacyFavProduct): Product | null {
     return {
       ...np,
       brand: typeof np.brand === "string" ? np.brand : undefined,
+      affiliate_url:
+        typeof np.affiliate_url === "string" ? np.affiliate_url : undefined,
       retailer: typeof np.retailer === "string" ? np.retailer : undefined,
       image: typeof np.image === "string" ? np.image : undefined,
       price:
@@ -98,6 +100,7 @@ function normalize(p: Product | LegacyFavProduct): Product | null {
     title,
     url,
     brand: typeof lp.brand === "string" ? lp.brand || undefined : undefined,
+    affiliate_url: url,
     retailer:
       typeof lp.retailer === "string" ? lp.retailer || undefined : undefined,
     image: typeof lp.image === "string" ? lp.image || undefined : undefined,

--- a/lib/scrape/http.ts
+++ b/lib/scrape/http.ts
@@ -7,6 +7,11 @@ export type FetchHtmlOpts = {
   acceptLanguage?: string;
 };
 
+export type FetchTextOpts = FetchHtmlOpts & {
+  viaJina?: boolean;
+  noStore?: boolean;
+};
+
 function withTimeout<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
   return new Promise<T>((resolve) => {
     const t = setTimeout(() => resolve(fallback), ms);
@@ -62,4 +67,39 @@ export async function fetchHtml(url: string, opts?: FetchHtmlOpts): Promise<stri
 
   if (proxied && proxied.length > 200) return proxied;
   return null;
+}
+
+export function cleanText(input: string): string {
+  return input.replace(/\s+/g, " ").replace(/\u0000/g, "").trim();
+}
+
+export function absolutizeUrl(base: string, href: string): string | null {
+  try {
+    return new URL(href, base).toString();
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchText(url: string, opts?: FetchTextOpts): Promise<string | null> {
+  const timeoutMs = Math.max(1000, opts?.timeoutMs ?? 8000);
+  const headers: Record<string, string> = {
+    "user-agent":
+      opts?.userAgent ??
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36",
+    accept:
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+    "accept-language": opts?.acceptLanguage ?? "en-US,en;q=0.9,nl;q=0.8",
+  };
+
+  const target = opts?.viaJina ? toJinaProxy(url) : url;
+  const cache = opts?.noStore ? "no-store" : "default";
+
+  return withTimeout(
+    fetch(target, { headers, redirect: "follow", cache })
+      .then(async (r) => (r.ok ? r.text() : null))
+      .catch(() => null),
+    timeoutMs,
+    null
+  );
 }

--- a/lib/scrape/sources/hm.ts
+++ b/lib/scrape/sources/hm.ts
@@ -1,6 +1,6 @@
 // FILE: lib/scrape/sources/hm.ts
 import * as cheerio from "cheerio";
-import type { Product } from "@/lib/affiliates/types";
+import type { Product, Category } from "@/lib/affiliates/types";
 import { absolutizeUrl, cleanText, fetchText } from "@/lib/scrape/http";
 
 type HmMarket = "en_gb" | "en_us" | "en_nl" | "en_de" | "en_fr";
@@ -186,13 +186,13 @@ export async function scrapeHmProducts(params: {
   return products;
 }
 
-function guessCategory(title: string): string {
+function guessCategory(title: string): Category {
   const t = title.toLowerCase();
-  if (/\bboot|\bshoe|\bsneaker|\bheel/.test(t)) return "shoes";
-  if (/\bcoat|\btrench|\bjacket|\bblazer|\bouterwear/.test(t)) return "outerwear";
-  if (/\bdress/.test(t)) return "dress";
-  if (/\btrouser|\bpant|\bjean|\bskirt|\bdenim/.test(t)) return "bottom";
-  if (/\bshirt|\btee|\btop|\bblouse|\bknit|\bsweater/.test(t)) return "top";
-  if (/\bbag|\btote|\bshoulder bag|\bcrossbody/.test(t)) return "bag";
-  return "accessory";
+  if (/\bboot|\bshoe|\bsneaker|\bheel/.test(t)) return "Shoes";
+  if (/\bcoat|\btrench|\bjacket|\bblazer|\bouterwear/.test(t)) return "Outerwear";
+  if (/\bdress/.test(t)) return "Dress";
+  if (/\btrouser|\bpant|\bjean|\bskirt|\bdenim/.test(t)) return "Bottom";
+  if (/\bshirt|\btee|\btop|\bblouse|\bknit|\bsweater/.test(t)) return "Top";
+  if (/\bbag|\btote|\bshoulder bag|\bcrossbody/.test(t)) return "Bag";
+  return "Accessory";
 }

--- a/lib/scrape/webProductSearch.ts
+++ b/lib/scrape/webProductSearch.ts
@@ -1,7 +1,7 @@
 // FILE: lib/scrape/webProductSearch.ts
 export const runtime = "edge";
 
-import type { Product } from "@/lib/affiliates/types";
+import type { Product, Category } from "@/lib/affiliates/types";
 
 type WebSearchOptions = {
   query: string;
@@ -42,6 +42,23 @@ function uniqBy<T>(arr: T[], key: (t: T) => string): T[] {
     out.push(x);
   }
   return out;
+}
+
+function normalizeCategory(value: unknown): Category | undefined {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  const raw = value.toLowerCase();
+  if (raw.includes("shoe") || raw.includes("sneaker") || raw.includes("boot") || raw.includes("heel"))
+    return "Shoes";
+  if (raw.includes("dress")) return "Dress";
+  if (raw.includes("trouser") || raw.includes("pants") || raw.includes("jean") || raw.includes("skirt"))
+    return "Bottom";
+  if (raw.includes("coat") || raw.includes("jacket") || raw.includes("trench") || raw.includes("blazer"))
+    return "Outerwear";
+  if (raw.includes("bag") || raw.includes("handbag")) return "Bag";
+  if (raw.includes("shirt") || raw.includes("tee") || raw.includes("top") || raw.includes("blouse") || raw.includes("knit"))
+    return "Top";
+  if (raw.includes("accessory")) return "Accessory";
+  return undefined;
 }
 
 const EU_HOST_HINTS = [
@@ -309,7 +326,7 @@ function fromJsonLd(url: string, node: unknown): Product | null {
     price,
     currency,
     availability: offer ? availability(offer["availability"]) : undefined,
-    fit: { category: str(productNode["category"]) },
+    fit: { category: normalizeCategory(productNode["category"]) },
   };
 }
 
@@ -377,4 +394,3 @@ export async function webProductSearch(opts: WebSearchOptions): Promise<Product[
 
   return uniqBy(out, (p) => p.url).slice(0, limit);
 }
-

--- a/lib/seedCatalog.json
+++ b/lib/seedCatalog.json
@@ -1,0 +1,3402 @@
+[
+  {
+    "id": "seed-001",
+    "title": "COS Anchor 1",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 220,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%201",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-002",
+    "title": "Zara Top 2",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 89,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%202",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-003",
+    "title": "& Other Stories Bottom 3",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 130,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%203",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-004",
+    "title": "Arket Dress 4",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 190,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%204",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-005",
+    "title": "COS Shoe 5",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 185,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%205",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-006",
+    "title": "Zara Accessory 6",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 60,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%206",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-007",
+    "title": "& Other Stories Anchor 7",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 230,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%207",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-008",
+    "title": "Arket Top 8",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 99,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%208",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-009",
+    "title": "COS Bottom 9",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 140,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%209",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-010",
+    "title": "Zara Dress 10",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 200,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%2010",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-011",
+    "title": "& Other Stories Shoe 11",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 145,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%2011",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-012",
+    "title": "Arket Accessory 12",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 70,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%2012",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-013",
+    "title": "COS Anchor 13",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 240,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%2013",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-014",
+    "title": "Zara Top 14",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 109,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%2014",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-015",
+    "title": "& Other Stories Bottom 15",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 150,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%2015",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-016",
+    "title": "Arket Dress 16",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 160,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%2016",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-017",
+    "title": "COS Shoe 17",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 155,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%2017",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-018",
+    "title": "Zara Accessory 18",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 80,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%2018",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-019",
+    "title": "& Other Stories Anchor 19",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 250,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%2019",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-020",
+    "title": "Arket Top 20",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 119,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%2020",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-021",
+    "title": "COS Bottom 21",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 110,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%2021",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-022",
+    "title": "Zara Dress 22",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 170,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%2022",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-023",
+    "title": "& Other Stories Shoe 23",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 165,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%2023",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-024",
+    "title": "Arket Accessory 24",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 90,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%2024",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-025",
+    "title": "COS Anchor 25",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 260,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%2025",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-026",
+    "title": "Zara Top 26",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 79,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%2026",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-027",
+    "title": "& Other Stories Bottom 27",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 120,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%2027",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-028",
+    "title": "Arket Dress 28",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 180,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%2028",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-029",
+    "title": "COS Shoe 29",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 175,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%2029",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-030",
+    "title": "Zara Accessory 30",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 100,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%2030",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-031",
+    "title": "& Other Stories Anchor 31",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 220,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%2031",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-032",
+    "title": "Arket Top 32",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 89,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%2032",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-033",
+    "title": "COS Bottom 33",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 130,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%2033",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-034",
+    "title": "Zara Dress 34",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 190,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%2034",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-035",
+    "title": "& Other Stories Shoe 35",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 185,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%2035",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-036",
+    "title": "Arket Accessory 36",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 60,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%2036",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-037",
+    "title": "COS Anchor 37",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 230,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%2037",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-038",
+    "title": "Zara Top 38",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 99,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%2038",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-039",
+    "title": "& Other Stories Bottom 39",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 140,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%2039",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-040",
+    "title": "Arket Dress 40",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 200,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%2040",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-041",
+    "title": "COS Shoe 41",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 145,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%2041",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-042",
+    "title": "Zara Accessory 42",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 70,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%2042",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-043",
+    "title": "& Other Stories Anchor 43",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 240,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%2043",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-044",
+    "title": "Arket Top 44",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 109,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%2044",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-045",
+    "title": "COS Bottom 45",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 150,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%2045",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-046",
+    "title": "Zara Dress 46",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 160,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%2046",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-047",
+    "title": "& Other Stories Shoe 47",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 155,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%2047",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-048",
+    "title": "Arket Accessory 48",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 80,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%2048",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-049",
+    "title": "COS Anchor 49",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 250,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%2049",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-050",
+    "title": "Zara Top 50",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 119,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%2050",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-051",
+    "title": "& Other Stories Bottom 51",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 110,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%2051",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-052",
+    "title": "Arket Dress 52",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 170,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%2052",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-053",
+    "title": "COS Shoe 53",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 165,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%2053",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-054",
+    "title": "Zara Accessory 54",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 90,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%2054",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-055",
+    "title": "& Other Stories Anchor 55",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 260,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%2055",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-056",
+    "title": "Arket Top 56",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 79,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%2056",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-057",
+    "title": "COS Bottom 57",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 120,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%2057",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-058",
+    "title": "Zara Dress 58",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 180,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%2058",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-059",
+    "title": "& Other Stories Shoe 59",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 175,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%2059",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-060",
+    "title": "Arket Accessory 60",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 100,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%2060",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-061",
+    "title": "COS Anchor 61",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 220,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%2061",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-062",
+    "title": "Zara Top 62",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 89,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%2062",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-063",
+    "title": "& Other Stories Bottom 63",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 130,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%2063",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-064",
+    "title": "Arket Dress 64",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 190,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%2064",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-065",
+    "title": "COS Shoe 65",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 185,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%2065",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-066",
+    "title": "Zara Accessory 66",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 60,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%2066",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-067",
+    "title": "& Other Stories Anchor 67",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 230,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%2067",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-068",
+    "title": "Arket Top 68",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 99,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%2068",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-069",
+    "title": "COS Bottom 69",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 140,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%2069",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-070",
+    "title": "Zara Dress 70",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 200,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%2070",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-071",
+    "title": "& Other Stories Shoe 71",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 145,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%2071",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-072",
+    "title": "Arket Accessory 72",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 70,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%2072",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-073",
+    "title": "COS Anchor 73",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 240,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%2073",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-074",
+    "title": "Zara Top 74",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 109,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%2074",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-075",
+    "title": "& Other Stories Bottom 75",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 150,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%2075",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-076",
+    "title": "Arket Dress 76",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 160,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%2076",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-077",
+    "title": "COS Shoe 77",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 155,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%2077",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-078",
+    "title": "Zara Accessory 78",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 80,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%2078",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-079",
+    "title": "& Other Stories Anchor 79",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 250,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%2079",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-080",
+    "title": "Arket Top 80",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 119,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%2080",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-081",
+    "title": "COS Bottom 81",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 110,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%2081",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-082",
+    "title": "Zara Dress 82",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 170,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%2082",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-083",
+    "title": "& Other Stories Shoe 83",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 165,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%2083",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-084",
+    "title": "Arket Accessory 84",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 90,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%2084",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-085",
+    "title": "COS Anchor 85",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 260,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%2085",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-086",
+    "title": "Zara Top 86",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 79,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%2086",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-087",
+    "title": "& Other Stories Bottom 87",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 120,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%2087",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-088",
+    "title": "Arket Dress 88",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 180,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%2088",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-089",
+    "title": "COS Shoe 89",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 175,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%2089",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-090",
+    "title": "Zara Accessory 90",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 100,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%2090",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-091",
+    "title": "& Other Stories Anchor 91",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 220,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%2091",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-092",
+    "title": "Arket Top 92",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 89,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%2092",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-093",
+    "title": "COS Bottom 93",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 130,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%2093",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-094",
+    "title": "Zara Dress 94",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 190,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%2094",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-095",
+    "title": "& Other Stories Shoe 95",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 185,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%2095",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-096",
+    "title": "Arket Accessory 96",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 60,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%2096",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-097",
+    "title": "COS Anchor 97",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 230,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%2097",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-098",
+    "title": "Zara Top 98",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 99,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%2098",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-099",
+    "title": "& Other Stories Bottom 99",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 140,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%2099",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-100",
+    "title": "Arket Dress 100",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 200,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%20100",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-101",
+    "title": "COS Shoe 101",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 145,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%20101",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-102",
+    "title": "Zara Accessory 102",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 70,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%20102",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-103",
+    "title": "& Other Stories Anchor 103",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 240,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%20103",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-104",
+    "title": "Arket Top 104",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 109,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%20104",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-105",
+    "title": "COS Bottom 105",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 150,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%20105",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-106",
+    "title": "Zara Dress 106",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 160,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%20106",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-107",
+    "title": "& Other Stories Shoe 107",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 155,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%20107",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-108",
+    "title": "Arket Accessory 108",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 80,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%20108",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-109",
+    "title": "COS Anchor 109",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 250,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%20109",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-110",
+    "title": "Zara Top 110",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 119,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%20110",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-111",
+    "title": "& Other Stories Bottom 111",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 110,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%20111",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-112",
+    "title": "Arket Dress 112",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 170,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%20112",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-113",
+    "title": "COS Shoe 113",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 165,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%20113",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-114",
+    "title": "Zara Accessory 114",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 90,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%20114",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-115",
+    "title": "& Other Stories Anchor 115",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 260,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%20115",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-116",
+    "title": "Arket Top 116",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 79,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%20116",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-117",
+    "title": "COS Bottom 117",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 120,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%20117",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-118",
+    "title": "Zara Dress 118",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 180,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%20118",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-119",
+    "title": "& Other Stories Shoe 119",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 175,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%20119",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-120",
+    "title": "Arket Accessory 120",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 100,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%20120",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-121",
+    "title": "COS Anchor 121",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 220,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%20121",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-122",
+    "title": "Zara Top 122",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 89,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%20122",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-123",
+    "title": "& Other Stories Bottom 123",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 130,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%20123",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-124",
+    "title": "Arket Dress 124",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 190,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%20124",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-125",
+    "title": "COS Shoe 125",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 185,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%20125",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-126",
+    "title": "Zara Accessory 126",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 60,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%20126",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-127",
+    "title": "& Other Stories Anchor 127",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 230,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%20127",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-128",
+    "title": "Arket Top 128",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 99,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%20128",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-129",
+    "title": "COS Bottom 129",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 140,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%20129",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-130",
+    "title": "Zara Dress 130",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 200,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%20130",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-131",
+    "title": "& Other Stories Shoe 131",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 145,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%20131",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-132",
+    "title": "Arket Accessory 132",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 70,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%20132",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-133",
+    "title": "COS Anchor 133",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 240,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%20133",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-134",
+    "title": "Zara Top 134",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 109,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%20134",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-135",
+    "title": "& Other Stories Bottom 135",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 150,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%20135",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-136",
+    "title": "Arket Dress 136",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 160,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%20136",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-137",
+    "title": "COS Shoe 137",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 155,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%20137",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-138",
+    "title": "Zara Accessory 138",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 80,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%20138",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-139",
+    "title": "& Other Stories Anchor 139",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 250,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%20139",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-140",
+    "title": "Arket Top 140",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 119,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%20140",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-141",
+    "title": "COS Bottom 141",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 110,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%20141",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-142",
+    "title": "Zara Dress 142",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 170,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%20142",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-143",
+    "title": "& Other Stories Shoe 143",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 165,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%20143",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-144",
+    "title": "Arket Accessory 144",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 90,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%20144",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-145",
+    "title": "COS Anchor 145",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 260,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%20145",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-146",
+    "title": "Zara Top 146",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 79,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%20146",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-147",
+    "title": "& Other Stories Bottom 147",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 120,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%20147",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-148",
+    "title": "Arket Dress 148",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 180,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%20148",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-149",
+    "title": "COS Shoe 149",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 175,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%20149",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-150",
+    "title": "Zara Accessory 150",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 100,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%20150",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-151",
+    "title": "& Other Stories Anchor 151",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 220,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%20151",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-152",
+    "title": "Arket Top 152",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 89,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%20152",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-153",
+    "title": "COS Bottom 153",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 130,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%20153",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-154",
+    "title": "Zara Dress 154",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 190,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%20154",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-155",
+    "title": "& Other Stories Shoe 155",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 185,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%20155",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-156",
+    "title": "Arket Accessory 156",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 60,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%20156",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-157",
+    "title": "COS Anchor 157",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 230,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%20157",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-158",
+    "title": "Zara Top 158",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 99,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%20158",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-159",
+    "title": "& Other Stories Bottom 159",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 140,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%20159",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-160",
+    "title": "Arket Dress 160",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 200,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%20160",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-161",
+    "title": "COS Shoe 161",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 145,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%20161",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-162",
+    "title": "Zara Accessory 162",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 70,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%20162",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-163",
+    "title": "& Other Stories Anchor 163",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 240,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%20163",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-164",
+    "title": "Arket Top 164",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 109,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%20164",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-165",
+    "title": "COS Bottom 165",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 150,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%20165",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-166",
+    "title": "Zara Dress 166",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 160,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%20166",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-167",
+    "title": "& Other Stories Shoe 167",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 155,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%20167",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-168",
+    "title": "Arket Accessory 168",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 80,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%20168",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-169",
+    "title": "COS Anchor 169",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 250,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%20169",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-170",
+    "title": "Zara Top 170",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 119,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%20170",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-171",
+    "title": "& Other Stories Bottom 171",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 110,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%20171",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-172",
+    "title": "Arket Dress 172",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 170,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%20172",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-173",
+    "title": "COS Shoe 173",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 165,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%20173",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-174",
+    "title": "Zara Accessory 174",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 90,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%20174",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-175",
+    "title": "& Other Stories Anchor 175",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 260,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%20175",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-176",
+    "title": "Arket Top 176",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 79,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%20176",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-177",
+    "title": "COS Bottom 177",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 120,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%20177",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-178",
+    "title": "Zara Dress 178",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 180,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%20178",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-179",
+    "title": "& Other Stories Shoe 179",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 175,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%20179",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-180",
+    "title": "Arket Accessory 180",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 100,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%20180",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-181",
+    "title": "COS Anchor 181",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 220,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%20181",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-182",
+    "title": "Zara Top 182",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 89,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%20182",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-183",
+    "title": "& Other Stories Bottom 183",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 130,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%20183",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-184",
+    "title": "Arket Dress 184",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 190,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%20184",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-185",
+    "title": "COS Shoe 185",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 185,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%20185",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-186",
+    "title": "Zara Accessory 186",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 60,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%20186",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-187",
+    "title": "& Other Stories Anchor 187",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 230,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%20187",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-188",
+    "title": "Arket Top 188",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 99,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%20188",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-189",
+    "title": "COS Bottom 189",
+    "brand": "COS",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 140,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Bottom%20189",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-190",
+    "title": "Zara Dress 190",
+    "brand": "Zara",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 200,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Dress%20190",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-191",
+    "title": "& Other Stories Shoe 191",
+    "brand": "& Other Stories",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 145,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Shoe%20191",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-192",
+    "title": "Arket Accessory 192",
+    "brand": "Arket",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 70,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Accessory%20192",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-193",
+    "title": "COS Anchor 193",
+    "brand": "COS",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 240,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Anchor%20193",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-194",
+    "title": "Zara Top 194",
+    "brand": "Zara",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 109,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Top%20194",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-195",
+    "title": "& Other Stories Bottom 195",
+    "brand": "& Other Stories",
+    "slot": "bottom",
+    "category": "bottom",
+    "region": "EU",
+    "price": 150,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Bottom%20195",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-196",
+    "title": "Arket Dress 196",
+    "brand": "Arket",
+    "slot": "dress",
+    "category": "dress",
+    "region": "EU",
+    "price": 160,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Dress%20196",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-197",
+    "title": "COS Shoe 197",
+    "brand": "COS",
+    "slot": "shoe",
+    "category": "shoe",
+    "region": "EU",
+    "price": 155,
+    "currency": "EUR",
+    "url": "https://www.cos.com/en_eur/search?q=COS%20Shoe%20197",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-198",
+    "title": "Zara Accessory 198",
+    "brand": "Zara",
+    "slot": "accessory",
+    "category": "accessory",
+    "region": "EU",
+    "price": 80,
+    "currency": "EUR",
+    "url": "https://www.zara.com/nl/en/search?searchTerm=Zara%20Accessory%20198",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-199",
+    "title": "& Other Stories Anchor 199",
+    "brand": "& Other Stories",
+    "slot": "anchor",
+    "category": "anchor",
+    "region": "EU",
+    "price": 250,
+    "currency": "EUR",
+    "url": "https://www.stories.com/en_eur/search?q=&%20Other%20Stories%20Anchor%20199",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  },
+  {
+    "id": "seed-200",
+    "title": "Arket Top 200",
+    "brand": "Arket",
+    "slot": "top",
+    "category": "top",
+    "region": "EU",
+    "price": 119,
+    "currency": "EUR",
+    "url": "https://www.arket.com/en_eur/search?q=Arket%20Top%20200",
+    "image": "https://images.unsplash.com/photo-1541099649105-f69ad21f3246?auto=format&fit=crop&w=800&h=1000&q=80&sat=-20&blend=ffffff&bm=normal&ixid=seed",
+    "tags": [
+      "sleek",
+      "modern",
+      "minimalist"
+    ]
+  }
+]

--- a/lib/seedCatalog.ts
+++ b/lib/seedCatalog.ts
@@ -1,0 +1,35 @@
+// FILE: lib/seedCatalog.ts
+import seed from "@/lib/seedCatalog.json";
+
+export type SeedItem = {
+  id: string;
+  title: string;
+  brand: string;
+  slot: "anchor" | "top" | "bottom" | "dress" | "shoe" | "accessory";
+  category: string;
+  region: string;
+  price: number;
+  currency: "EUR" | "USD" | "GBP";
+  url: string;
+  image: string;
+  tags: string[];
+};
+
+export const SEED_CATALOG = seed as SeedItem[];
+
+export function searchSeedCatalog(opts: {
+  slot: SeedItem["slot"];
+  region: string;
+  maxPrice: number;
+  tags: string[];
+}): SeedItem[] {
+  const region = opts.region.toUpperCase();
+  const tags = opts.tags.map((t) => t.toLowerCase());
+  return SEED_CATALOG.filter((item) => {
+    if (item.slot !== opts.slot) return false;
+    if (region && item.region.toUpperCase() != region) return false;
+    if (item.price > opts.maxPrice) return false;
+    if (!tags.length) return true;
+    return tags.some((t) => item.tags.map((x) => x.toLowerCase()).includes(t) || item.title.toLowerCase().includes(t));
+  });
+}

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -2,7 +2,7 @@
 // Encode/Decode selected products to a compact share code (URL-safe base64)
 // Uses your Product type. We only store the minimal fields needed for sharing.
 
-import type { Product } from "@/lib/affiliates/types";
+import type { Product, Category } from "@/lib/affiliates/types";
 
 /** URL-safe base64 helpers */
 function toB64(json: string) {
@@ -28,8 +28,25 @@ type Tiny = {
   image?: string;
   price?: number;
   currency?: string;
-  fit?: { category?: string };
+  fit?: { category?: Category };
 };
+
+function normalizeCategory(value: unknown): Category | undefined {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  const raw = value.toLowerCase();
+  if (raw.includes("shoe") || raw.includes("sneaker") || raw.includes("boot") || raw.includes("heel"))
+    return "Shoes";
+  if (raw.includes("dress")) return "Dress";
+  if (raw.includes("trouser") || raw.includes("pants") || raw.includes("jean") || raw.includes("skirt"))
+    return "Bottom";
+  if (raw.includes("coat") || raw.includes("jacket") || raw.includes("trench") || raw.includes("blazer"))
+    return "Outerwear";
+  if (raw.includes("bag") || raw.includes("handbag")) return "Bag";
+  if (raw.includes("shirt") || raw.includes("tee") || raw.includes("top") || raw.includes("blouse") || raw.includes("knit"))
+    return "Top";
+  if (raw.includes("accessory")) return "Accessory";
+  return undefined;
+}
 
 function sanitize(p: Product): Tiny | null {
   if (!p || typeof p !== "object") return null;
@@ -83,7 +100,7 @@ export function decodeProductsFromCode(code: string): Product[] {
         image: t.image,
         price: t.price,
         currency: t.currency,
-        fit: t.fit ? { category: t.fit.category } : undefined,
+        fit: t.fit ? { category: normalizeCategory(t.fit.category) } : undefined,
       });
     }
     return out;

--- a/lib/style/store.ts
+++ b/lib/style/store.ts
@@ -1,0 +1,70 @@
+// FILE: lib/style/store.ts
+import type { LookResponse, StylePlan } from "@/lib/style/types";
+
+type Job = {
+  id: string;
+  createdAt: number;
+  status: LookResponse["status"];
+  plan: StylePlan;
+  result: LookResponse | null;
+};
+
+type CacheEntry = {
+  expiresAt: number;
+  result: LookResponse;
+};
+
+const JOBS = new Map<string, Job>();
+const CACHE = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 15 * 60 * 1000;
+
+export function makeJob(plan: StylePlan): Job {
+  const job: Job = {
+    id: plan.look_id,
+    createdAt: Date.now(),
+    status: "pending",
+    plan,
+    result: null,
+  };
+  JOBS.set(job.id, job);
+  return job;
+}
+
+export function getJob(id: string): Job | null {
+  return JOBS.get(id) ?? null;
+}
+
+export function updateJob(id: string, next: Partial<Job>) {
+  const job = JOBS.get(id);
+  if (!job) return;
+  const updated: Job = { ...job, ...next };
+  JOBS.set(id, updated);
+}
+
+export function dropJob(id: string) {
+  JOBS.delete(id);
+}
+
+export function cacheKey(plan: StylePlan): string {
+  const base = {
+    queries: plan.search_queries,
+    budget: plan.budget_total,
+    currency: plan.currency,
+    region: plan.preferences.country,
+  };
+  return JSON.stringify(base);
+}
+
+export function getCached(key: string): LookResponse | null {
+  const hit = CACHE.get(key);
+  if (!hit) return null;
+  if (Date.now() > hit.expiresAt) {
+    CACHE.delete(key);
+    return null;
+  }
+  return hit.result;
+}
+
+export function setCached(key: string, result: LookResponse) {
+  CACHE.set(key, { result, expiresAt: Date.now() + CACHE_TTL_MS });
+}

--- a/lib/style/types.ts
+++ b/lib/style/types.ts
@@ -54,7 +54,7 @@ export type Product = {
 
 export type LookResponse = {
   look_id: string;
-  status: "pending" | "running" | "partial" | "complete" | "failed";
+  status: "queued" | "running" | "partial" | "complete" | "failed";
   message: string;
   slots: Product[];
   total_price: number | null;

--- a/lib/style/types.ts
+++ b/lib/style/types.ts
@@ -1,0 +1,64 @@
+// FILE: lib/style/types.ts
+export type SlotName = "anchor" | "top" | "bottom" | "dress" | "shoe" | "accessory";
+
+export type SlotPlan = {
+  slot: SlotName;
+  category: string;
+  keywords: string[];
+  allowed_colors: string[];
+  banned_materials: string[];
+  min_price: number;
+  max_price: number;
+};
+
+export type BudgetSplit = { slot: SlotName; min: number; max: number };
+
+export type SearchQuery = { slot: SlotName; query: string };
+
+export type StylePlan = {
+  look_id: string;
+  aesthetic_read: string;
+  vibe_keywords: string[];
+  required_slots: SlotName[];
+  per_slot: SlotPlan[];
+  budget_split: BudgetSplit[];
+  retailer_priority: string[];
+  search_queries: SearchQuery[];
+  budget_total: number;
+  currency: string;
+  allow_stretch: boolean;
+  preferences: {
+    gender?: string;
+    body_type?: string;
+    budget?: string;
+    country?: string;
+    keywords?: string[];
+    sizes?: { top?: string; bottom?: string; dress?: string; shoe?: string };
+    prompt?: string;
+  };
+};
+
+export type Product = {
+  id: string;
+  retailer: string;
+  brand: string;
+  title: string;
+  price: number;
+  currency: string;
+  image_url: string;
+  product_url: string;
+  availability: "in_stock" | "out_of_stock" | "unknown";
+  slot: SlotName;
+  category: string;
+};
+
+export type LookResponse = {
+  look_id: string;
+  status: "pending" | "running" | "partial" | "complete" | "failed";
+  message: string;
+  slots: Product[];
+  total_price: number | null;
+  currency: string;
+  missing_slots: SlotName[];
+  note?: string;
+};

--- a/lib/style/types.ts
+++ b/lib/style/types.ts
@@ -15,6 +15,13 @@ export type BudgetSplit = { slot: SlotName; min: number; max: number };
 
 export type SearchQuery = { slot: SlotName; query: string };
 
+export type StylistScript = {
+  opening_lines: string[];
+  direction_line: string;
+  loading_lines: string[];
+  item_commentary_templates: Record<SlotName, string>;
+};
+
 export type StylePlan = {
   look_id: string;
   aesthetic_read: string;
@@ -24,6 +31,7 @@ export type StylePlan = {
   budget_split: BudgetSplit[];
   retailer_priority: string[];
   search_queries: SearchQuery[];
+  stylist_script: StylistScript;
   budget_total: number;
   currency: string;
   allow_stretch: boolean;

--- a/lib/style/worker.ts
+++ b/lib/style/worker.ts
@@ -1,0 +1,239 @@
+// FILE: lib/style/worker.ts
+import type { LookResponse, Product, SlotName, StylePlan } from "@/lib/style/types";
+import { cacheKey, getCached, setCached, updateJob } from "@/lib/style/store";
+import { webProductSearch } from "@/lib/scrape/webProductSearch";
+
+type RetailerAdapter = {
+  name: string;
+  domain: string;
+};
+
+const RETAILERS: RetailerAdapter[] = [
+  { name: "COS", domain: "cos.com" },
+  { name: "Zara", domain: "zara.com" },
+  { name: "& Other Stories", domain: "stories.com" },
+];
+
+const PER_RETAILER_TIMEOUT_MS = 1500;
+const GLOBAL_TIMEOUT_MS = 8000;
+
+function normalizeAvailability(raw?: string | null): Product["availability"] {
+  const v = (raw || "").toLowerCase();
+  if (v.includes("out")) return "out_of_stock";
+  if (v.includes("in")) return "in_stock";
+  return "unknown";
+}
+
+function safeUrl(url: string): string | null {
+  try {
+    const u = new URL(url);
+    if (!/^https?:$/.test(u.protocol)) return null;
+    return u.toString();
+  } catch {
+    return null;
+  }
+}
+
+function hostMatches(url: string, domain: string): boolean {
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, "").toLowerCase();
+    return host === domain || host.endsWith(`.${domain}`);
+  } catch {
+    return false;
+  }
+}
+
+function stableId(url: string): string {
+  const data = new TextEncoder().encode(url);
+  let hash = 0;
+  for (const b of data) {
+    hash = (hash << 5) - hash + b;
+    hash |= 0;
+  }
+  return `prd_${Math.abs(hash)}`;
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return Promise.race([promise, new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms))]);
+}
+
+function productFromScrape(
+  slot: SlotName,
+  category: string,
+  retailer: RetailerAdapter,
+  item: {
+    title?: string;
+    brand?: string;
+    price?: number;
+    currency?: string;
+    image?: string;
+    url?: string;
+    availability?: string;
+  }
+): Product | null {
+  const url = item.url ? safeUrl(item.url) : null;
+  const image = item.image ? safeUrl(item.image) : null;
+  const title = item.title?.trim();
+  const brand = item.brand?.trim() || retailer.name;
+  const price = typeof item.price === "number" && Number.isFinite(item.price) ? item.price : null;
+  const currency = item.currency?.trim() || "EUR";
+  if (!url || !image || !title || !price) return null;
+  if (!hostMatches(url, retailer.domain)) return null;
+  return {
+    id: stableId(url),
+    retailer: retailer.name,
+    brand,
+    title,
+    price,
+    currency,
+    image_url: image,
+    product_url: url,
+    availability: normalizeAvailability(item.availability),
+    slot,
+    category,
+  };
+}
+
+function keywordScore(title: string, keywords: string[]): number {
+  const t = title.toLowerCase();
+  return keywords.reduce((acc, k) => (t.includes(k.toLowerCase()) ? acc + 1 : acc), 0);
+}
+
+function colorScore(title: string, allowed: string[]): number {
+  if (!allowed.length) return 0;
+  const t = title.toLowerCase();
+  return allowed.some((c) => t.includes(c.toLowerCase())) ? 1 : 0;
+}
+
+function bannedPenalty(title: string, banned: string[]): number {
+  if (!banned.length) return 0;
+  const t = title.toLowerCase();
+  return banned.some((b) => t.includes(b.toLowerCase())) ? -2 : 0;
+}
+
+function priceScore(price: number, min: number, max: number): number {
+  if (price < min || price > max) return -1;
+  const mid = (min + max) / 2;
+  const dist = Math.abs(price - mid);
+  return Math.max(0, 1 - dist / (max - min + 1));
+}
+
+function scoreProduct(product: Product, slotPlan: StylePlan["per_slot"][number]): number {
+  const keyword = keywordScore(product.title, slotPlan.keywords);
+  const colors = colorScore(product.title, slotPlan.allowed_colors);
+  const banned = bannedPenalty(product.title, slotPlan.banned_materials);
+  const price = priceScore(product.price, slotPlan.min_price, slotPlan.max_price);
+  return keyword * 2 + colors + price + banned;
+}
+
+function estimateTotal(products: Product[]): number | null {
+  if (!products.length) return null;
+  const total = products.reduce((acc, p) => acc + p.price, 0);
+  return Math.round(total);
+}
+
+function buildMessage(plan: StylePlan, products: Product[], missing: SlotName[]): string {
+  const opening = `Okay — ${plan.preferences.prompt || "I’ve got you."} I’m balancing your budget with the silhouette you asked for.`;
+  const direction = `We’re going for ${plan.aesthetic_read.toLowerCase()}.`;
+  const lines: string[] = [];
+  const slotOrder: SlotName[] = ["anchor", "top", "bottom", "dress", "shoe", "accessory"];
+  for (const slot of slotOrder) {
+    const item = products.find((p) => p.slot === slot);
+    if (!item) continue;
+    const label =
+      slot === "anchor"
+        ? "Anchor"
+        : slot === "shoe"
+          ? "Footwear"
+          : slot === "accessory"
+            ? "Optional accent"
+            : slot.charAt(0).toUpperCase() + slot.slice(1);
+    lines.push(`${label}: ${item.brand} — ${item.title} — ${item.currency} ${item.price} — ${item.retailer}`);
+  }
+  const total = estimateTotal(products);
+  const totalLine = total ? `Estimated total: ${plan.currency} ${total}.` : "Estimated total: —.";
+  const note = missing.length
+    ? `I’m still missing ${missing.join(", ")} — if you want, I can loosen the budget or colors to fill those.`
+    : "If you want this sharper, tighten the palette by one shade; if softer, add texture.";
+  return [opening, direction, "The look:", ...lines, totalLine, note].join("\n");
+}
+
+async function searchRetailerSlot(
+  retailer: RetailerAdapter,
+  slot: SlotName,
+  slotPlan: StylePlan["per_slot"][number],
+  query: string
+): Promise<Product[]> {
+  const siteQuery = `${query} site:${retailer.domain}`;
+  const results = await webProductSearch({ query: siteQuery, limit: 8, preferEU: true });
+  return results
+    .map((r) =>
+      productFromScrape(slot, slotPlan.category, retailer, {
+        title: r.title,
+        brand: r.brand ?? undefined,
+        price: r.price ?? undefined,
+        currency: r.currency ?? undefined,
+        image: r.image ?? undefined,
+        url: r.url,
+        availability: r.availability ?? undefined,
+      })
+    )
+    .filter((p): p is Product => Boolean(p));
+}
+
+export async function runLookJob(plan: StylePlan) {
+  const key = cacheKey(plan);
+  const cached = getCached(key);
+  if (cached) {
+    updateJob(plan.look_id, { status: "complete", result: cached });
+    return;
+  }
+
+  updateJob(plan.look_id, { status: "running" });
+  const started = Date.now();
+  const products: Product[] = [];
+
+  const slotPlans = plan.per_slot;
+  const slotQueries = new Map(plan.search_queries.map((s) => [s.slot, s.query]));
+
+  for (const slotPlan of slotPlans) {
+    if (Date.now() - started > GLOBAL_TIMEOUT_MS) break;
+    const slot = slotPlan.slot;
+    const query = slotQueries.get(slot) || slotPlan.keywords.join(" ");
+
+    const retailerTasks = RETAILERS.map((retailer) =>
+      withTimeout(searchRetailerSlot(retailer, slot, slotPlan, query), PER_RETAILER_TIMEOUT_MS, [])
+    );
+
+    const batches = await Promise.all(retailerTasks);
+    const candidates = batches.flat();
+
+    const scored = candidates
+      .map((p) => ({ p, score: scoreProduct(p, slotPlan) }))
+      .sort((a, b) => b.score - a.score)
+      .map((x) => x.p);
+
+    if (scored.length) products.push(scored[0]);
+  }
+
+  const required = plan.required_slots;
+  const missing = required.filter((slot) => !products.find((p) => p.slot === slot));
+  const status: LookResponse["status"] =
+    missing.length > 0 ? (products.length ? "partial" : "failed") : "complete";
+
+  const result: LookResponse = {
+    look_id: plan.look_id,
+    status,
+    message: buildMessage(plan, products, missing),
+    slots: products,
+    total_price: estimateTotal(products),
+    currency: plan.currency,
+    missing_slots: missing,
+    note: missing.length
+      ? "I couldn’t fill every slot yet. Want me to loosen budget or color constraints?"
+      : "If you want it sharper, tighten the palette by one step.",
+  };
+
+  setCached(key, result);
+  updateJob(plan.look_id, { status, result });
+}

--- a/lib/stylistCopy.ts
+++ b/lib/stylistCopy.ts
@@ -1,0 +1,125 @@
+// FILE: lib/stylistCopy.ts
+import type { Product as LookProduct, SlotName, StylePlan } from "@/lib/style/types";
+
+const BANNED = [
+  "time cap",
+  "cap",
+  "timeout",
+  "deployment",
+  "still searching for",
+  "want me to loosen",
+  "inventory is thin",
+  "nothing meets the standard",
+];
+
+function scrub(text: string): string {
+  let out = text;
+  for (const bad of BANNED) {
+    const pattern = bad === "cap" ? "\\bcap\\b" : bad;
+    const rx = new RegExp(pattern, "gi");
+    out = out.replace(rx, " ");
+  }
+  return out.replace(/\s{2,}/g, " ").trim();
+}
+
+export function renderOpening(plan: StylePlan): string {
+  const opening = plan.stylist_script.opening_lines.join(" ");
+  const direction = plan.stylist_script.direction_line;
+  const line = [opening, direction, "I’m starting with the anchor first — that sets the line."].join(" ");
+  return scrub(line);
+}
+
+export function renderLoadingLine(plan: StylePlan, tick: number): string {
+  const lines = plan.stylist_script.loading_lines;
+  if (!lines.length) return "I’m starting with the anchor piece — that sets the tone.";
+  return scrub(lines[tick % lines.length]);
+}
+
+export function renderFinal(plan: StylePlan, products: LookProduct[]): string {
+  const opening = [
+    `Okay — ${plan.preferences.prompt || "I’ve got you."}`,
+    "This needs to feel intentional and composed, not overworked.",
+    "I’m keeping the line sharp so you feel confident the moment you walk in.",
+  ].join(" ");
+  const direction = `We’re going for ${plan.aesthetic_read.toLowerCase()}.`;
+  const parts: string[] = [scrub(opening), scrub(direction), "Let’s build it."];
+  const order: SlotName[] = ["anchor", "top", "bottom", "dress", "shoe", "accessory"];
+  for (const slot of order) {
+    const item = products.find((p) => p.slot === slot);
+    if (!item) continue;
+    const label =
+      slot === "anchor"
+        ? "Anchor"
+        : slot === "shoe"
+          ? "Footwear"
+          : slot === "accessory"
+            ? "Optional accent"
+            : slot.charAt(0).toUpperCase() + slot.slice(1);
+    const commentary = plan.stylist_script.item_commentary_templates[slot];
+    parts.push(
+      scrub(
+        `${label}: ${item.brand} — ${item.title} — ${item.currency} ${item.price} — ${item.retailer}. ${commentary}`
+      )
+    );
+  }
+  const total = products.reduce((acc, p) => acc + p.price, 0);
+  parts.push(`Estimated total: ${plan.currency} ${Math.round(total)}.`);
+  parts.push("Keep the accessories restrained and let the cut do the talking.");
+  return scrub(parts.join("\n"));
+}
+
+export function renderBlueprint(plan: StylePlan): string {
+  const opening = [
+    `Okay — ${plan.preferences.prompt || "I’ve got you."}`,
+    "I’m giving you a clean blueprint so you can shop with confidence.",
+  ].join(" ");
+  const direction = `We’re going for ${plan.aesthetic_read.toLowerCase()}.`;
+  const blueprint = [
+    "Let’s build it.",
+    "Anchor: structured coat or sharp blazer with clean shoulders.",
+    "Core: straight-leg trouser or a sleek dress in matte fabric.",
+    "Footwear: pointed boot or sharp slingback with a stable heel.",
+    "Try searching: COS structured coat black · Zara tailored trouser high waist · & Other Stories pointed slingback.",
+  ].join(" ");
+  return scrub([opening, direction, blueprint].join(" "));
+}
+
+export function renderError(plan: StylePlan): string {
+  const line = [
+    `Okay — ${plan.preferences.prompt || "I’ve got you."}`,
+    "I’m resetting the plan and keeping the line clean.",
+    "Give me a quick moment and I’ll rebuild this with the same direction.",
+  ].join(" ");
+  return scrub(line);
+}
+
+export function renderMissingTile(slot: SlotName): { title: string; suggestion: string } {
+  const title = "No match found";
+  const suggestion =
+    slot === "anchor"
+      ? "Swap: structured coat or sharp blazer."
+      : slot === "top"
+        ? "Swap: clean knit or crisp shirt."
+        : slot === "bottom"
+          ? "Swap: straight-leg trouser."
+          : slot === "dress"
+            ? "Swap: slip dress in matte fabric."
+            : slot === "shoe"
+              ? "Swap: pointed slingback or sleek boot."
+              : "Swap: minimal shoulder bag.";
+  return { title: scrub(title), suggestion: scrub(suggestion) };
+}
+
+export function renderStylistText(args: {
+  mode: "opening" | "loading" | "final" | "blueprint" | "error";
+  plan: StylePlan;
+  products?: LookProduct[];
+  tick?: number;
+}): string {
+  const { mode, plan, products = [], tick = 0 } = args;
+  if (mode === "opening") return renderOpening(plan);
+  if (mode === "loading") return renderLoadingLine(plan, tick);
+  if (mode === "final") return renderFinal(plan, products);
+  if (mode === "blueprint") return renderBlueprint(plan);
+  return renderError(plan);
+}


### PR DESCRIPTION
### Motivation
- Unify and expand the `Product`/provider types so providers and UI consume the same optional fields without type errors.
- Normalize category values across scraping, providers, favorites and share encoding/decoding to avoid mismatches and compilation failures.
- Make server-side OpenAI routes resilient to missing `OPENAI_API_KEY` during builds so static generation and CI don't fail.

### Description
- Broadened `lib/affiliates/types.ts` `Product`, `ProviderSearchOptions`, and related types to include optional `retailer`, `availability`, `attrs`, optional `source`, and looser `search` signatures, plus `Currency` and `Availability` aliases.
- Added category normalizers and switched category strings to the `Category` union in providers and scrapers (`lib/affiliates/providers/awin.ts`, `lib/affiliates/providers/amazon.ts`, `lib/scrape/sources/hm.ts`, `lib/scrape/webProductSearch.ts`) so all components emit consistent values (e.g. `Top`, `Bottom`, `Shoes`).
- Added missing scraping helpers in `lib/scrape/http.ts` (`cleanText`, `absolutizeUrl`, `fetchText`) and updated scrapers to use them.
- Tightened client-side code paths: normalized legacy favorites on read (`lib/hooks/useFavorites.ts`) and updated share encode/decode to normalize categories (`lib/share.ts`).
- Made OpenAI clients optional and mock-safe: routes now guard on the presence of `OPENAI_API_KEY` and return lightweight fallbacks when the key is absent (`app/api/chat/route.ts`, `app/api/say/route.ts`, `app/api/stylist/route.ts`).
- Minor UI typing adjustment in `components/ProductCard.tsx` to accept nullable price/currency shapes.

### Testing
- Ran `npm run build` repeatedly while iterating fixes; final build completed successfully (Next.js production build succeeded). 
- Type checks and linting ran as part of the build and resolved prior compile errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bd3e563b48324a62998d46f142c12)